### PR TITLE
修复"分享中"计数不准确的问题

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -244,7 +244,7 @@ func NewApp(cfg *AppConfig, logger *zap.Logger, db *gorm.DB, efs embed.FS) (*App
 	a.GitSyncService = service.NewGitSyncService(a.GitSyncRepo, a.NoteRepo, a.FolderRepo, a.FileRepo, a.VaultRepo, &a.config.Git, a.logger)
 
 	a.FolderService = service.NewFolderService(a.FolderRepo, a.NoteRepo, a.FileRepo, a.VaultService, a.BackupService, a.workerPool)
-	a.NoteService = service.NewNoteService(a.NoteRepo, a.NoteLinkRepo, a.FileRepo, a.VaultService, a.FolderService, a.BackupService, a.GitSyncService, svcConfig)
+	a.NoteService = service.NewNoteService(a.NoteRepo, a.NoteLinkRepo, a.FileRepo, a.ShareRepo, a.VaultService, a.FolderService, a.BackupService, a.GitSyncService, svcConfig)
 	a.UserService = service.NewUserService(a.UserRepo, a.TokenManager, logger, svcConfig)
 	a.FileService = service.NewFileService(a.FileRepo, a.NoteRepo, a.VaultService, a.FolderService, a.BackupService, a.GitSyncService, svcConfig)
 	a.SettingService = service.NewSettingService(a.SettingRepo, a.VaultService, svcConfig)

--- a/internal/dao/user_share_repository.go
+++ b/internal/dao/user_share_repository.go
@@ -168,7 +168,7 @@ func (r *userShareRepository) ListByUID(ctx context.Context, uid int64, sortBy s
 
 	orderClause := field + " " + sortOrder
 	var ms []*model.UserShare
-	q := us.WithContext(ctx).Where(us.UID.Eq(uid))
+	q := us.WithContext(ctx).Where(us.UID.Eq(uid), us.Status.Eq(1))
 	if limit > 0 {
 		q = q.Limit(limit).Offset(offset)
 	}
@@ -201,7 +201,7 @@ func (r *userShareRepository) UpdatePassword(ctx context.Context, uid int64, id 
 
 func (r *userShareRepository) CountByUID(ctx context.Context, uid int64) (int64, error) {
 	us := r.userShare(uid).UserShare
-	return us.WithContext(ctx).Where(us.UID.Eq(uid)).Count()
+	return us.WithContext(ctx).Where(us.UID.Eq(uid), us.Status.Eq(1)).Count()
 }
 
 var _ domain.UserShareRepository = (*userShareRepository)(nil)

--- a/internal/service/note_service.go
+++ b/internal/service/note_service.go
@@ -121,27 +121,29 @@ type NoteService interface {
 // noteService implementation of NoteService interface
 // noteService 实现 NoteService 接口
 type noteService struct {
-	noteRepo       domain.NoteRepository     // Note repository // 笔记仓库
-	noteLinkRepo   domain.NoteLinkRepository // Note link repository // 笔记链接仓库
-	fileRepo       domain.FileRepository     // File repository // 文件仓库
-	vaultService   VaultService              // Vault service // 仓库服务
-	folderService  FolderService             // Folder service // 文件夹服务
-	sf             *singleflight.Group       // Singleflight group // 并发请求合并组
-	clientName     string                    // Client name // 客户端名称
-	clientVer      string                    // Client version // 客户端版本
-	config         *ServiceConfig            // Service configuration // 服务配置
-	backupService  BackupService             // Backup service // 备份服务
-	gitSyncService GitSyncService            // Git sync service // Git 同步服务
-	countTimers    sync.Map                  // Timers for CountSizeSum debounce // CountSizeSum 防抖计时器
+	noteRepo       domain.NoteRepository         // Note repository // 笔记仓库
+	noteLinkRepo   domain.NoteLinkRepository     // Note link repository // 笔记链接仓库
+	fileRepo       domain.FileRepository         // File repository // 文件仓库
+	shareRepo      domain.UserShareRepository    // Share repository for auto-revoke on delete // 分享仓库（删除时自动撤销）
+	vaultService   VaultService                  // Vault service // 仓库服务
+	folderService  FolderService                 // Folder service // 文件夹服务
+	sf             *singleflight.Group           // Singleflight group // 并发请求合并组
+	clientName     string                        // Client name // 客户端名称
+	clientVer      string                        // Client version // 客户端版本
+	config         *ServiceConfig                // Service configuration // 服务配置
+	backupService  BackupService                 // Backup service // 备份服务
+	gitSyncService GitSyncService                // Git sync service // Git 同步服务
+	countTimers    sync.Map                      // Timers for CountSizeSum debounce // CountSizeSum 防抖计时器
 }
 
 // NewNoteService creates NoteService instance
 // NewNoteService 创建 NoteService 实例
-func NewNoteService(noteRepo domain.NoteRepository, noteLinkRepo domain.NoteLinkRepository, fileRepo domain.FileRepository, vaultSvc VaultService, folderSvc FolderService, backupSvc BackupService, gitSyncSvc GitSyncService, config *ServiceConfig) NoteService {
+func NewNoteService(noteRepo domain.NoteRepository, noteLinkRepo domain.NoteLinkRepository, fileRepo domain.FileRepository, shareRepo domain.UserShareRepository, vaultSvc VaultService, folderSvc FolderService, backupSvc BackupService, gitSyncSvc GitSyncService, config *ServiceConfig) NoteService {
 	return &noteService{
 		noteRepo:       noteRepo,
 		noteLinkRepo:   noteLinkRepo,
 		fileRepo:       fileRepo,
+		shareRepo:      shareRepo,
 		vaultService:   vaultSvc,
 		folderService:  folderSvc,
 		backupService:  backupSvc,
@@ -159,6 +161,7 @@ func (s *noteService) WithClient(name, version string) NoteService {
 		noteRepo:       s.noteRepo,
 		noteLinkRepo:   s.noteLinkRepo,
 		fileRepo:       s.fileRepo,
+		shareRepo:      s.shareRepo,
 		vaultService:   s.vaultService,
 		folderService:  s.folderService,
 		sf:             s.sf,
@@ -423,6 +426,14 @@ func (s *noteService) Delete(ctx context.Context, uid int64, params *dto.NoteDel
 	err = s.noteRepo.UpdateDelete(ctx, note, uid)
 	if err != nil {
 		return nil, code.ErrorDBQuery.WithDetails(err.Error())
+	}
+
+	// 若笔记有 active 分享，自动撤销（防止计数残留）
+	// Auto-revoke active share if exists, to prevent stale count
+	if s.shareRepo != nil {
+		if share, err := s.shareRepo.GetByRes(ctx, uid, "note", note.ID); err == nil && share != nil {
+			_ = s.shareRepo.UpdateStatus(ctx, uid, share.ID, 2)
+		}
 	}
 
 	// 重新获取更新后的笔记

--- a/internal/service/share_service.go
+++ b/internal/service/share_service.go
@@ -249,6 +249,12 @@ func (s *shareService) ShareGenerate(ctx context.Context, uid int64, vaultName s
 		UpdatedAt: time.Now(),
 	}
 
+	// 幂等：若该资源已有 active 分享，先撤销，避免重复计数
+	// Idempotent: revoke any existing active share before creating a new one
+	if existing, err := s.repo.GetByRes(ctx, uid, mainType, mainID); err == nil && existing != nil {
+		_ = s.StopShare(ctx, uid, existing.ID)
+	}
+
 	if err := s.repo.Create(ctx, uid, share); err != nil {
 		return nil, err
 	}
@@ -459,11 +465,13 @@ func (s *shareService) ListShares(ctx context.Context, uid int64, sortBy string,
 		switch share.ResType {
 		case "note":
 			if note, err := s.noteRepo.GetByID(ctx, share.ResID, uid); err == nil && note != nil {
-				baseName := filepath.Base(note.Path)
-				// Remove .md suffix for note title
-				// 去掉 .md 后缀作为标题
-				item.Title = strings.TrimSuffix(baseName, ".md")
-				item.NotePath = note.Path
+				if note.Action != domain.NoteActionDelete {
+					baseName := filepath.Base(note.Path)
+					// Remove .md suffix for note title
+					// 去掉 .md 后缀作为标题
+					item.Title = strings.TrimSuffix(baseName, ".md")
+					item.NotePath = note.Path
+				}
 			}
 		case "file":
 			if file, err := s.fileRepo.GetByID(ctx, share.ResID, uid); err == nil && file != nil {


### PR DESCRIPTION
## Summary

- **ShareGenerate 增加幂等检查**：创建分享前先撤销该资源已有的 active 分享记录，避免笔记重命名后多次创建分享导致多条 active 记录并存，引起计数偏高
- **笔记删除时自动撤销关联分享**：`noteService.Delete` 删除笔记后，自动将关联的 active 分享撤销（status=2），防止已删除笔记的分享仍被计入"分享中"计数
- **ListShares 过滤已删除笔记**：`ListShares` 填充 `NotePath` 时增加 `action != delete` 检查，避免已删除笔记的路径出现在前端分享列表中
- **ListByUID/CountByUID 只返回有效分享**：增加 `status=1` 过滤，减少无效数据传输

## Test plan

- [ ] 对分享中的笔记执行重命名，然后再次点击"创建分享"，验证"分享中"计数仍为 1
- [ ] 将有分享的笔记移入回收站，验证"分享中"计数立即减少（分享被自动撤销）
- [ ] 取消分享后计数正确归零

🤖 Generated with [Claude Code](https://claude.com/claude-code)