### PR TITLE
为文件和笔记仓储接口添加分页支持，并在 Git 同步服务中实现批量处理，解决大仓库容易导致OOM问题

### DIFF
--- a/internal/dao/file_repository.go
+++ b/internal/dao/file_repository.go
@@ -434,12 +434,24 @@ func (r *fileRepository) ListCount(ctx context.Context, vaultID, uid int64, keyw
 
 // ListByUpdatedTimestamp 根据更新时间戳获取文件列表
 func (r *fileRepository) ListByUpdatedTimestamp(ctx context.Context, timestamp, vaultID, uid int64) ([]*domain.File, error) {
+	return r.ListByUpdatedTimestampPage(ctx, timestamp, vaultID, uid, 0, 0)
+}
+
+// ListByUpdatedTimestampPage 根据更新时间戳分页获取文件列表
+func (r *fileRepository) ListByUpdatedTimestampPage(ctx context.Context, timestamp, vaultID, uid int64, offset, limit int) ([]*domain.File, error) {
 	u := r.file(uid).File
-	mList, err := u.WithContext(ctx).Where(
+	query := u.WithContext(ctx).Where(
 		u.VaultID.Eq(vaultID),
 		u.UpdatedTimestamp.Gt(timestamp),
-	).Order(u.UpdatedTimestamp.Desc()).
-		Find()
+	).Order(u.UpdatedTimestamp.Desc())
+
+	var mList []*model.File
+	var err error
+	if limit > 0 {
+		mList, _, err = query.FindByPage(offset, limit)
+	} else {
+		mList, err = query.Find()
+	}
 
 	if err != nil {
 		return nil, err

--- a/internal/dao/note_repository.go
+++ b/internal/dao/note_repository.go
@@ -746,12 +746,24 @@ func (r *noteRepository) ListCount(ctx context.Context, vaultID, uid int64, keyw
 
 // ListByUpdatedTimestamp 根据更新时间戳获取笔记列表
 func (r *noteRepository) ListByUpdatedTimestamp(ctx context.Context, timestamp, vaultID, uid int64) ([]*domain.Note, error) {
+	return r.ListByUpdatedTimestampPage(ctx, timestamp, vaultID, uid, 0, 0)
+}
+
+// ListByUpdatedTimestampPage 根据更新时间戳分页获取笔记列表
+func (r *noteRepository) ListByUpdatedTimestampPage(ctx context.Context, timestamp, vaultID, uid int64, offset, limit int) ([]*domain.Note, error) {
 	u := r.note(uid).Note
-	mList, err := u.WithContext(ctx).Where(
+	query := u.WithContext(ctx).Where(
 		u.VaultID.Eq(vaultID),
 		u.UpdatedTimestamp.Gt(timestamp),
-	).Order(u.UpdatedTimestamp.Desc()).
-		Find()
+	).Order(u.UpdatedTimestamp.Desc())
+
+	var mList []*model.Note
+	var err error
+	if limit > 0 {
+		mList, _, err = query.FindByPage(offset, limit)
+	} else {
+		mList, err = query.Find()
+	}
 
 	if err != nil {
 		return nil, err

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -64,6 +64,9 @@ type NoteRepository interface {
 	// ListByUpdatedTimestamp 根据更新时间戳获取笔记列表
 	ListByUpdatedTimestamp(ctx context.Context, timestamp, vaultID, uid int64) ([]*Note, error)
 
+	// ListByUpdatedTimestampPage 根据更新时间戳分页获取笔记列表
+	ListByUpdatedTimestampPage(ctx context.Context, timestamp, vaultID, uid int64, offset, limit int) ([]*Note, error)
+
 	// ListContentUnchanged 获取内容未变更的笔记列表
 	ListContentUnchanged(ctx context.Context, uid int64) ([]*Note, error)
 
@@ -215,6 +218,9 @@ type FileRepository interface {
 
 	// ListByUpdatedTimestamp 根据更新时间戳获取文件列表
 	ListByUpdatedTimestamp(ctx context.Context, timestamp, vaultID, uid int64) ([]*File, error)
+
+	// ListByUpdatedTimestampPage 根据更新时间戳分页获取文件列表
+	ListByUpdatedTimestampPage(ctx context.Context, timestamp, vaultID, uid int64, offset, limit int) ([]*File, error)
 
 	// ListByMtime 根据修改时间戳获取文件列表
 	ListByMtime(ctx context.Context, timestamp, vaultID, uid int64) ([]*File, error)

--- a/internal/service/git_sync_service.go
+++ b/internal/service/git_sync_service.go
@@ -31,6 +31,8 @@ import (
 // errNoChanges 表示 Git 同步检查后没有发现任何需要提交的变更
 var errNoChanges = errors.New("no changes found")
 
+const gitSyncBatchSize = 100
+
 // GitSyncService 定义 Git 同步业务服务接口
 type GitSyncService interface {
 	GetConfigs(ctx context.Context, uid int64) ([]*dto.GitSyncConfigDTO, error)
@@ -541,6 +543,8 @@ func (s *gitSyncService) doSync(ctx context.Context, conf *domain.GitSyncConfig)
 			Auth:          auth,
 			ReferenceName: plumbing.NewBranchReferenceName(conf.Branch),
 			SingleBranch:  true,
+			Depth:         1,
+			Tags:          git.NoTags,
 		})
 		if err != nil {
 			if errors.Is(err, transport.ErrEmptyRemoteRepository) {
@@ -581,6 +585,7 @@ func (s *gitSyncService) doSync(ctx context.Context, conf *domain.GitSyncConfig)
 		ReferenceName: plumbing.NewBranchReferenceName(conf.Branch),
 		SingleBranch:  true,
 		Force:         true,
+		Depth:         1,
 	})
 	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		if errors.Is(err, transport.ErrEmptyRemoteRepository) || errors.Is(err, git.ErrRemoteNotFound) || errors.Is(err, plumbing.ErrReferenceNotFound) {
@@ -665,23 +670,58 @@ func (s *gitSyncService) mirrorNotesToWorkspace(ctx context.Context, conf *domai
 		s.logger.Info("Performing initial full sync to workspace (using unified incremental method)", zap.Int64("configId", conf.ID))
 	}
 
-	notes, err := s.noteRepo.ListByUpdatedTimestamp(ctx, ts, v.ID, conf.UID)
-	if err != nil {
-		return false, err
-	}
-
-	files, err := s.fileRepo.ListByUpdatedTimestamp(ctx, ts, v.ID, conf.UID)
-	if err != nil {
-		return false, err
-	}
-
-	if len(notes) == 0 && len(files) == 0 {
-		return false, nil
-	}
-
 	var actuallyChanged bool
 
-	// 1. Process Notes
+	for offset := 0; ; offset += gitSyncBatchSize {
+		notes, err := s.noteRepo.ListByUpdatedTimestampPage(ctx, ts, v.ID, conf.UID, offset, gitSyncBatchSize)
+		if err != nil {
+			return false, err
+		}
+		if len(notes) == 0 {
+			break
+		}
+
+		batchChanged, err := s.processNotesBatch(notes, wsPath)
+		if err != nil {
+			return false, err
+		}
+		if batchChanged {
+			actuallyChanged = true
+		}
+
+		if len(notes) < gitSyncBatchSize {
+			break
+		}
+	}
+
+	for offset := 0; ; offset += gitSyncBatchSize {
+		files, err := s.fileRepo.ListByUpdatedTimestampPage(ctx, ts, v.ID, conf.UID, offset, gitSyncBatchSize)
+		if err != nil {
+			return false, err
+		}
+		if len(files) == 0 {
+			break
+		}
+
+		batchChanged, err := s.processFilesBatch(files, conf, wsPath)
+		if err != nil {
+			return false, err
+		}
+		if batchChanged {
+			actuallyChanged = true
+		}
+
+		if len(files) < gitSyncBatchSize {
+			break
+		}
+	}
+
+	return actuallyChanged, nil
+}
+
+func (s *gitSyncService) processNotesBatch(notes []*domain.Note, wsPath string) (bool, error) {
+	var actuallyChanged bool
+
 	for _, n := range notes {
 		targetPath := n.Path
 		if filepath.Ext(targetPath) == "" {
@@ -722,7 +762,12 @@ func (s *gitSyncService) mirrorNotesToWorkspace(ctx context.Context, conf *domai
 		}
 	}
 
-	// 2. Process Files
+	return actuallyChanged, nil
+}
+
+func (s *gitSyncService) processFilesBatch(files []*domain.File, conf *domain.GitSyncConfig, wsPath string) (bool, error) {
+	var actuallyChanged bool
+
 	for _, f := range files {
 		fullPath := filepath.Join(wsPath, f.Path)
 


### PR DESCRIPTION
根因在 Git 同步实现里有两个高内存点叠加。
第一，首次同步会做完整 clone/pull，之前没有限制历史深度，位置在 [git_sync_service.go:546] 和 [git_sync_service.go:588]。
第二，更关键的是它会一次性把某个 vault 下所有变更笔记和附件全部查出来再处理，原来是整批加载；笔记内容还会从文件系统读回内存，仓库稍大就容易峰值爆掉。我已经把这部分改成分页批处理，批大小是 100，见 [git_sync_service.go:34]、[git_sync_service.go:676]、[git_sync_service.go:698]、[git_sync_service.go:722]。对应地，仓储接口和 DAO 也补了分页方法，在 [repository.go:67]、[repository.go:222]、[note_repository.go:753]、[file_repository.go:441]。

原OOM错误日志如下：

```
2026-03-27T02:43:36.967648815Z [GIN] 2026/03/27 - 10:43:36 | 200 |   1.97ms |    124.64.22.25 | GET      "/api/git-sync/histories?page=1&pageSize=10&_=1774579416316_2ja1ij5zar5&lang=zh-CN"
2026-03-27T02:43:36.968887980Z [GIN] 2026/03/27 - 10:43:36 | 200 |   1.77ms |    124.64.22.25 | GET      "/api/git-sync/configs?_=1774579416316_n588tw7s0ts&lang=zh-CN"
2026-03-27T02:43:36.987233486Z [GIN] 2026/03/27 - 10:43:36 | 200 |   1.07ms |    124.64.22.25 | GET      "/api/vault?limit=100&_=1774579416316_4pgcbh1oqhe&lang=zh-CN"
2026-03-27T02:43:50.087636113Z [GIN] 2026/03/27 - 10:43:50 | 200 |   2.63ms |    124.64.22.25 | DELETE   "/api/git-sync/config?id=1&_=1774579429825_e58uvbibrt7&lang=zh-CN"
2026-03-27T02:43:50.471618677Z [GIN] 2026/03/27 - 10:43:50 | 200 |   1.14ms |    124.64.22.25 | GET      "/api/git-sync/configs?_=1774579430242_hz61spz0c26&lang=zh-CN"
2026-03-27T02:43:50.471669121Z [GIN] 2026/03/27 - 10:43:50 | 200 |   1.16ms |    124.64.22.25 | GET      "/api/vault?limit=100&_=1774579430243_ulfzgp3lbgl&lang=zh-CN"
2026-03-27T02:44:26.424333840Z [GIN] 2026/03/27 - 10:44:26 | 200 | 172.18ms |    124.64.22.25 | POST     "/api/git-sync/validate?_=1774579465991_bnugpkqggdw&lang=zh-CN"
2026-03-27T02:44:33.093760948Z [GIN] 2026/03/27 - 10:44:33 | 200 |   3.38ms |    124.64.22.25 | POST     "/api/git-sync/config?_=1774579472801_xqhgxzk6ehc&lang=zh-CN"
2026-03-27T02:44:33.484406961Z [GIN] 2026/03/27 - 10:44:33 | 200 |   1.24ms |    124.64.22.25 | GET      "/api/vault?limit=100&_=1774579473250_ycsv35wg9o&lang=zh-CN"
2026-03-27T02:44:33.484696206Z [GIN] 2026/03/27 - 10:44:33 | 200 |   2.24ms |    124.64.22.25 | GET      "/api/git-sync/configs?_=1774579473250_sf0nppx3rdt&lang=zh-CN"
2026-03-27T02:44:38.525720364Z [GIN] 2026/03/27 - 10:44:38 | 200 |   1.42ms |    124.64.22.25 | POST     "/api/git-sync/config/execute?_=1774579478292_vdx3ob26he&lang=zh-CN"
2026-03-27T02:44:39.919282545Z [GIN] 2026/03/27 - 10:44:39 | 200 | 745.815µs |    124.64.22.25 | GET      "/api/git-sync/configs?_=1774579479691_ta8sljaghjo&lang=zh-CN"
2026-03-27T02:44:39.919847950Z [GIN] 2026/03/27 - 10:44:39 | 200 | 543.961µs |    124.64.22.25 | GET      "/api/vault?limit=100&_=1774579479691_9q7z6sbnz8&lang=zh-CN"
2026-03-27T02:44:39.928359414Z [GIN] 2026/03/27 - 10:44:39 | 200 | 486.091µs |    124.64.22.25 | GET      "/api/git-sync/histories?page=1&pageSize=10&_=1774579479691_ztmfziz9jdm&lang=zh-CN"
2026-03-27T02:47:42.114233745Z Killed
2026-03-27T02:47:43.053836874Z 2026-03-27T10:47:43.053+0800	WARN	
2026-03-27T02:47:43.053892730Z     ______           __     _   __      __          _____
2026-03-27T02:47:43.053902891Z    / ____/___ ______/ /_   / | / /___  / /____     / ___/__  ______  _____
2026-03-27T02:47:43.053909469Z   / /_  / __  / ___/ __/  /  |/ / __ \/ __/ _ \    \__ \/ / / / __ \/ ___/
2026-03-27T02:47:43.053915598Z  / __/ / /_/ (__  ) /_   / /|  / /_/ / /_/  __/   ___/ / /_/ / / / / /__
2026-03-27T02:47:43.053920909Z /_/    \__,_/____/\__/  /_/ |_/\____/\__/\___/   /____/\__, /_/ /_/\___/
2026-03-27T02:47:43.053946509Z                                                       /____/              
2026-03-27T02:47:43.053954372Z 
2026-03-27T02:47:43.053960052Z Fast Note Sync Service v2.9.3
2026-03-27T02:47:43.053965642Z Git: 88ea765
2026-03-27T02:47:43.053970969Z BuildTime: 2026-03-24T15:38:08+0000
```