### PR TITLE
修复分享状态同步问题，简化分享状态同步，移除上次新增的分享更新增量接口

### DIFF
--- a/internal/app/version.go
+++ b/internal/app/version.go
@@ -5,7 +5,7 @@ package app
 // Version information variables, injected during build
 // 版本信息变量，由构建时注入
 var (
-	Version   string = "2.11.2"
+	Version   string = "2.11.3"
 	GitTag    string = "2000.01.01.release"
 	BuildTime string = "2000-01-01T00:00:00+0800"
 )

--- a/internal/dao/user_share_repository.go
+++ b/internal/dao/user_share_repository.go
@@ -238,26 +238,4 @@ func (r *userShareRepository) ListActiveNoteResIDs(ctx context.Context, uid int6
 	return ids, nil
 }
 
-// ListChangedNoteResIDs 返回 updated_at > since 的 note 分享记录，按状态分组
-// ListChangedNoteResIDs returns note share res_ids changed after since, grouped by status
-func (r *userShareRepository) ListChangedNoteResIDs(ctx context.Context, uid int64, since time.Time) ([]int64, []int64, error) {
-	us := r.userShare(uid).UserShare
-	ms, err := us.WithContext(ctx).
-		Where(us.UID.Eq(uid), us.ResType.Eq("note"), us.UpdatedAt.Gt(timex.Time(since))).
-		Find()
-	if err != nil {
-		return nil, nil, err
-	}
-	var active, revoked []int64
-	for _, m := range ms {
-		switch m.Status {
-		case domain.UserShareStatusActive:
-			active = append(active, m.ResID)
-		case domain.UserShareStatusRevoked:
-			revoked = append(revoked, m.ResID)
-		}
-	}
-	return active, revoked, nil
-}
-
 var _ domain.UserShareRepository = (*userShareRepository)(nil)

--- a/internal/domain/domain_user_share.go
+++ b/internal/domain/domain_user_share.go
@@ -51,9 +51,4 @@ type UserShareRepository interface {
 	// ListActiveNoteResIDs returns note res_ids for all active shares of a user
 	// ListActiveNoteResIDs 返回该用户所有有效分享中 res_type='note' 的 res_id 列表
 	ListActiveNoteResIDs(ctx context.Context, uid int64) ([]int64, error)
-	// ListChangedNoteResIDs returns res_ids of note shares whose status changed after since,
-	// split into active (added) and revoked (removed) slices.
-	// ListChangedNoteResIDs 返回 updated_at > since 的 note 分享记录的 res_id，
-	// 按状态分为 active（新增）和 revoked（取消）两组。
-	ListChangedNoteResIDs(ctx context.Context, uid int64, since time.Time) (active []int64, revoked []int64, err error)
 }

--- a/internal/dto/share_dto.go
+++ b/internal/dto/share_dto.go
@@ -104,19 +104,3 @@ type ShareListItem struct {
 type ShareListResponse struct {
 	Items []*ShareListItem `json:"items"` // Share list // 分享列表
 }
-
-// ShareChangesRequest 获取分享变更请求
-// ShareChangesRequest request parameters for fetching share changes
-type ShareChangesRequest struct {
-	Vault string `json:"vault" form:"vault" binding:"required"` // Vault name // 保险库名称
-	Since int64  `json:"since" form:"since"`                    // Unix timestamp (ms); 0 means full refresh required // Unix 毫秒时间戳；0 表示需要全量拉取
-}
-
-// ShareChangesData 分享路径变更响应数据
-// ShareChangesData response payload for share path changes
-type ShareChangesData struct {
-	Added               []string `json:"added"`               // Newly shared note paths since Since // Since 之后新增的分享路径
-	Removed             []string `json:"removed"`             // Cancelled share paths since Since // Since 之后取消的分享路径
-	LastTime            int64    `json:"lastTime"`            // Timestamp to use as Since in next request // 下次请求使用的时间戳
-	FullRefreshRequired bool     `json:"fullRefreshRequired"` // Client must call /share-paths for full refresh // 客户端需调用 /share-paths 做全量刷新
-}

--- a/internal/dto/ws_dto.go
+++ b/internal/dto/ws_dto.go
@@ -175,6 +175,12 @@ const (
 	// SettingSyncClear sync clear all settings
 	// SettingSyncClear 同步清理所有设置
 	SettingSyncClear WebSocketSendAction = "SettingSyncClear"
+
+	// ---------------- Share ----------------
+
+	// ShareSyncRefresh notify clients to refresh share state
+	// ShareSyncRefresh 通知客户端刷新分享状态
+	ShareSyncRefresh WebSocketSendAction = "ShareSyncRefresh"
 )
 
 // WSQueuedMessage represents a message item to be sent

--- a/internal/routers/api_router/handler_share.go
+++ b/internal/routers/api_router/handler_share.go
@@ -23,11 +23,11 @@ type ShareHandler struct {
 	*Handler
 }
 
-// NewShareHandler creates ShareHandler instance
-// NewShareHandler 创建 ShareHandler 实例
-func NewShareHandler(app *app.App) *ShareHandler {
+// NewShareHandler creates ShareHandler instance with WebSocket server
+// NewShareHandler 创建带 WebSocket 服务的 ShareHandler 实例
+func NewShareHandler(app *app.App, wss *pkgapp.WebsocketServer) *ShareHandler {
 	return &ShareHandler{
-		Handler: &Handler{App: app},
+		Handler: NewHandlerWithWSS(app, wss),
 	}
 }
 
@@ -70,9 +70,8 @@ func (h *ShareHandler) Create(c *gin.Context) {
 	}
 
 	response.ToResponse(code.Success.WithData(shareRes))
+	h.WSS.BroadcastToUser(uid, code.Success, dto.ShareSyncRefresh)
 }
-
-// GetShared retrieves shared note details
 // @Summary Get shared note details
 // @Description Get specific note content (restricted read-only access) via share token
 // @Tags Share
@@ -283,6 +282,7 @@ func (h *ShareHandler) Cancel(c *gin.Context) {
 	}
 
 	response.ToResponse(code.Success)
+	h.WSS.BroadcastToUser(uid, code.Success, dto.ShareSyncRefresh)
 }
 
 // UpdatePassword updates share password
@@ -437,39 +437,6 @@ func (h *ShareHandler) NoteSharePaths(c *gin.Context) {
 	}
 
 	response.ToResponse(code.Success.WithData(paths))
-}
-
-// NoteShareChanges returns share path changes since a given timestamp for a vault
-// NoteShareChanges 返回指定 vault 下 since 时间戳之后的分享路径变更，供客户端增量同步
-// @Summary Get share path changes since timestamp
-// @Tags Share
-// @Security UserAuthToken
-// @Param token header string true "Auth Token"
-// @Param params query dto.ShareChangesRequest true "Query Parameters"
-// @Success 200 {object} pkgapp.Res{data=dto.ShareChangesData} "Success"
-// @Router /api/notes/share-changes [get]
-func (h *ShareHandler) NoteShareChanges(c *gin.Context) {
-	response := pkgapp.NewResponse(c)
-	params := &dto.ShareChangesRequest{}
-	if valid, errs := pkgapp.BindAndValid(c, params); !valid {
-		response.ToResponse(code.ErrorInvalidParams.WithDetails(errs.ErrorsToString()).WithData(errs.MapsToString()))
-		return
-	}
-
-	uid := pkgapp.GetUID(c)
-	ctx := c.Request.Context()
-
-	data, err := h.App.ShareService.GetNoteShareChangesByVault(ctx, uid, params.Vault, params.Since)
-	if err != nil {
-		if cObj, ok := err.(*code.Code); ok {
-			response.ToResponse(cObj)
-		} else {
-			response.ToResponse(code.Failed.WithDetails(err.Error()))
-		}
-		return
-	}
-
-	response.ToResponse(code.Success.WithData(data))
 }
 
 // logError records error log, including Trace ID

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -162,7 +162,7 @@ func NewRouter(frontendFiles embed.FS, appContainer *app.App, uni *ut.UniversalT
 		noteHistoryHandler := api_router.NewNoteHistoryHandler(appContainer, wss)
 		versionHandler := api_router.NewVersionHandler(appContainer)
 		adminControlHandler := api_router.NewAdminControlHandler(appContainer, wss)
-		shareHandler := api_router.NewShareHandler(appContainer)
+		shareHandler := api_router.NewShareHandler(appContainer, wss)
 		storageHandler := api_router.NewStorageHandler(appContainer)
 		backupHandler := api_router.NewBackupHandler(appContainer)
 		gitSyncHandler := api_router.NewGitSyncHandler(appContainer)
@@ -241,7 +241,6 @@ func NewRouter(frontendFiles embed.FS, appContainer *app.App, uni *ut.UniversalT
 			auth.GET("/notes", noteHandler.List)
 			auth.DELETE("/note/recycle-clear", noteHandler.RecycleClear)
 			auth.GET("/notes/share-paths", shareHandler.NoteSharePaths)
-			auth.GET("/notes/share-changes", shareHandler.NoteShareChanges)
 
 			auth.GET("/folder", folderHandler.Get)
 			auth.POST("/folder", folderHandler.Create)

--- a/internal/service/share_service.go
+++ b/internal/service/share_service.go
@@ -84,10 +84,6 @@ type ShareService interface {
 	// GetActiveNotePathsByVault 返回指定 vault 下所有有效分享的笔记路径列表
 	GetActiveNotePathsByVault(ctx context.Context, uid int64, vaultName string) ([]string, error)
 
-	// GetNoteShareChangesByVault returns share path changes since sinceMs for a vault
-	// GetNoteShareChangesByVault 返回指定 vault 下 sinceMs 之后的分享路径变更
-	GetNoteShareChangesByVault(ctx context.Context, uid int64, vaultName string, sinceMs int64) (*dto.ShareChangesData, error)
-
 	// Shutdown shuts down the service and flushes remaining data
 	// Shutdown 关闭服务并同步最后的数据
 	Shutdown(ctx context.Context) error
@@ -691,71 +687,6 @@ func (s *shareService) GetActiveNotePathsByVault(ctx context.Context, uid int64,
 		}
 	}
 	return paths, nil
-}
-
-// GetNoteShareChangesByVault 返回指定 vault 下 sinceMs 之后的分享路径变更（两步查询，避免跨库 JOIN）
-// GetNoteShareChangesByVault returns note share path changes since sinceMs for a vault (two-step query, no cross-DB JOIN)
-func (s *shareService) GetNoteShareChangesByVault(ctx context.Context, uid int64, vaultName string, sinceMs int64) (*dto.ShareChangesData, error) {
-	// since=0 表示客户端无本地缓存，需要全量刷新 / since=0 means client has no cache, require full refresh
-	if sinceMs == 0 {
-		return &dto.ShareChangesData{
-			FullRefreshRequired: true,
-			Added:               []string{},
-			Removed:             []string{},
-			LastTime:            time.Now().UnixMilli(),
-		}, nil
-	}
-
-	vault, err := s.vaultRepo.GetByName(ctx, vaultName, uid)
-	if err != nil || vault == nil {
-		return nil, code.ErrorVaultNotFound
-	}
-
-	since := time.UnixMilli(sinceMs)
-
-	// 步骤1：查询 user_shares 中变更的 note res_id（无跨库 JOIN）
-	// Step 1: query changed note res_ids from user_shares (no cross-DB JOIN)
-	activeIDs, revokedIDs, err := s.repo.ListChangedNoteResIDs(ctx, uid, since)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &dto.ShareChangesData{
-		Added:    []string{},
-		Removed:  []string{},
-		LastTime: time.Now().UnixMilli(),
-	}
-
-	// 步骤2：合并 ID 列表，一次批量查询 notes，按 vault 过滤后按来源分拆
-	// Step 2: merge ID lists, single batch query for notes, filter by vault and split by source
-	allIDs := make([]int64, 0, len(activeIDs)+len(revokedIDs))
-	allIDs = append(allIDs, activeIDs...)
-	allIDs = append(allIDs, revokedIDs...)
-
-	if len(allIDs) > 0 {
-		activeSet := make(map[int64]struct{}, len(activeIDs))
-		for _, id := range activeIDs {
-			activeSet[id] = struct{}{}
-		}
-
-		notes, err := s.noteRepo.ListByIDs(ctx, allIDs, uid)
-		if err == nil {
-			for _, n := range notes {
-				if n.VaultID != vault.ID {
-					continue
-				}
-				if _, ok := activeSet[n.ID]; ok {
-					if n.Action != domain.NoteActionDelete {
-						result.Added = append(result.Added, n.Path)
-					}
-				} else {
-					result.Removed = append(result.Removed, n.Path)
-				}
-			}
-		}
-	}
-
-	return result, nil
 }
 
 // GetSharedNote retrieves specific shared note details


### PR DESCRIPTION
简化分享状态的同步机制，更稳定。
删除之前为分享状态同步引入的新接口和逻辑： getShareChanges 增量同步逻辑及 lastShareSyncTime 追踪
（以上接口只是上次新增的，仅服务分享状态更新的）
新增 ShareSyncRefresh WebSocket 消息处理器触发全量刷新，会在笔记、文件、配置同步结束后再同步分享状态，不阻塞主流程。
解决跨设备分享状态不同步的问题。

关联PR：https://github.com/haierkeys/obsidian-fast-note-sync/pull/101