### PR TITLE
fix: migrate share records on note rename

### DIFF
--- a/internal/dao/user_share_repository.go
+++ b/internal/dao/user_share_repository.go
@@ -260,4 +260,62 @@ func (r *userShareRepository) ListChangedNoteResIDs(ctx context.Context, uid int
 	return active, revoked, nil
 }
 
+// MigrateResID updates res_id and resources JSON when a note/file is renamed (old ID → new ID).
+// MigrateResID 在笔记/文件重命名时更新分享记录的资源 ID 和资源列表（旧 ID → 新 ID）。
+func (r *userShareRepository) MigrateResID(ctx context.Context, uid int64, oldResID int64, newResID int64) error {
+	return r.dao.ExecuteWrite(ctx, uid, r, func(db *gorm.DB) error {
+		us := r.userShare(uid).UserShare
+
+		// 1. Update res_id for all active shares pointing to oldResID
+		// 1. 更新所有指向旧 ID 的有效分享的 res_id
+		_, err := us.WithContext(ctx).
+			Where(us.UID.Eq(uid), us.ResID.Eq(oldResID), us.Status.Eq(domain.UserShareStatusActive)).
+			Update(us.ResID, newResID)
+		if err != nil {
+			return err
+		}
+
+		// 2. Update resources JSON: replace oldResID with newResID in all note/file arrays
+		// 2. 更新资源 JSON：在 note/file 数组中将旧 ID 替换为新 ID
+		oldIDStr := strconv.FormatInt(oldResID, 10)
+		newIDStr := strconv.FormatInt(newResID, 10)
+
+		shares, err := us.WithContext(ctx).
+			Where(us.UID.Eq(uid), us.Status.Eq(domain.UserShareStatusActive)).
+			Find()
+		if err != nil {
+			return err
+		}
+
+		for _, share := range shares {
+			var res map[string][]string
+			if err := json.Unmarshal([]byte(share.Res), &res); err != nil {
+				continue
+			}
+
+			changed := false
+			for key, ids := range res {
+				for i, id := range ids {
+					if id == oldIDStr {
+						ids[i] = newIDStr
+						changed = true
+					}
+				}
+			}
+
+			if changed {
+				resBytes, _ := json.Marshal(res)
+				_, err := us.WithContext(ctx).
+					Where(us.ID.Eq(share.ID)).
+					Update(us.Res, string(resBytes))
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
 var _ domain.UserShareRepository = (*userShareRepository)(nil)

--- a/internal/domain/domain_user_share.go
+++ b/internal/domain/domain_user_share.go
@@ -56,4 +56,7 @@ type UserShareRepository interface {
 	// ListChangedNoteResIDs 返回 updated_at > since 的 note 分享记录的 res_id，
 	// 按状态分为 active（新增）和 revoked（取消）两组。
 	ListChangedNoteResIDs(ctx context.Context, uid int64, since time.Time) (active []int64, revoked []int64, err error)
+	// MigrateResID updates res_id and resources JSON for a share when a note/file is renamed.
+	// MigrateResID 在笔记/文件重命名时更新分享记录的资源 ID 和资源列表。
+	MigrateResID(ctx context.Context, uid int64, oldResID int64, newResID int64) error
 }

--- a/internal/service/note_service.go
+++ b/internal/service/note_service.go
@@ -781,6 +781,18 @@ func (s *noteService) Migrate(ctx context.Context, oldNoteID, newNoteID int64, u
 		return code.ErrorDBQuery.WithDetails(err.Error())
 	}
 
+	// Migrate share records: update res_id and resources from old note ID to new note ID
+	// 迁移分享记录：将旧笔记 ID 的分享指向新笔记 ID
+	if s.shareRepo != nil {
+		if shareErr := s.shareRepo.MigrateResID(ctx, uid, oldNoteID, newNoteID); shareErr != nil {
+			// Log but don't fail the rename operation
+			s.logger.Warn("Migrate: failed to migrate share records",
+				zap.Int64("oldNoteID", oldNoteID),
+				zap.Int64("newNoteID", newNoteID),
+				zap.Error(shareErr))
+		}
+	}
+
 	go s.CountSizeSum(context.Background(), oldNote.VaultID, uid)
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #191

### Problem

When a note is renamed in Obsidian, FNS creates a new note record (new ID) and marks the old one as deleted (`rename=1`). However, share records in `user_share` table were not updated during this migration:

- `res_id` still pointed to the old (deleted) note ID
- `resources` JSON still contained the old note ID

This caused shared links to become stale — they would either show deleted content or, if another note later reused the same path, incorrectly point to the new note.

### Solution

Added `MigrateResID` method to `UserShareRepository` that:
1. Updates `res_id` for all active shares pointing to the old note ID
2. Replaces the old note ID in the `resources` JSON map (handles both main note and attachment references)

Called from `NoteService.Migrate` with non-blocking error handling (logs warning but doesn't fail the rename).

### Files Changed
- `internal/domain/domain_user_share.go`: Added `MigrateResID` to interface
- `internal/dao/user_share_repository.go`: Implemented `MigrateResID`
- `internal/service/note_service.go`: Call share migration in `Migrate`