### PR TITLE
fix(backup): skip missing files during archive export instead of failing

### DIFF
--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -694,7 +694,16 @@ func (s *backupService) exportArchiveFiles(ctx context.Context, uid, vaultID int
 			}
 		} else {
 			if err := util.CopyFile(localPath, destPath); err != nil {
-				return err
+			// Skip missing files instead of failing the entire backup.
+			// This can happen when the DB record exists but the file
+			// has been manually deleted or lost due to data inconsistency.
+			if os.IsNotExist(err) {
+				s.logger.Warn("Skipping backup of missing file",
+					zap.String("path", path),
+					zap.String("localPath", localPath))
+				return nil
+			}
+			return err
 			}
 		}
 		totalCount++


### PR DESCRIPTION
## Summary

When a file record exists in the database but the actual file on disk is missing (e.g., manually deleted or data inconsistency), the archive backup would fail entirely with `no such file or directory`.

## Problem

In `exportArchiveFiles()`, the `CopyFile` call for attachments does not handle the case where the source file doesn't exist:

```go
if err := util.CopyFile(localPath, destPath); err != nil {
    return err  // entire backup fails
}
```

Meanwhile, `syncFiles()` already handles this gracefully (line 830-835) by checking `os.Open` and logging a warning instead of failing.

## Fix

Add an `os.IsNotExist` check before returning the error, mirroring the existing behavior in `syncFiles()`. Missing files are skipped with a warning log, allowing the rest of the backup to proceed.

## Related

Closes #210