### PR TITLE
feat:增强在文件传输过程中断（如断网、退出客户端等）的稳定性

### DIFF
--- a/internal/dto/file_dto_ws.go
+++ b/internal/dto/file_dto_ws.go
@@ -65,7 +65,8 @@ type FileSyncDeleteMessage struct {
 // FileRenameAckMessage ack message for file rename operation, carries server timestamp
 // FileRenameAckMessage 文件重命名操作 ack 消息，携带服务端时间戳
 type FileRenameAckMessage struct {
-	LastTime int64 `json:"lastTime"` // Server timestamp after rename // 重命名后的服务端时间戳
+	LastTime int64  `json:"lastTime"` // Server timestamp after rename // 重命名后的服务端时间戳
+	Path     string `json:"path"`     // New file path after rename // 重命名后的文件新路径
 }
 
 // FileUploadAckMessage ack message for file upload complete, carries server timestamp and file path

--- a/internal/dto/file_dto_ws.go
+++ b/internal/dto/file_dto_ws.go
@@ -75,6 +75,13 @@ type FileUploadAckMessage struct {
 	Path     string `json:"path"`     // File path // 文件路径
 }
 
+// FileDeleteAckMessage file delete operation ACK, sent back to sender after server processes FileDelete
+// FileDeleteAckMessage 文件删除操作 ACK，服务端处理完 FileDelete 后回发给发送方
+type FileDeleteAckMessage struct {
+	LastTime int64  `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
+	Path     string `json:"path"`     // File path // 文件路径
+}
+
 // FileSyncRenameMessage message structure for file rename during sync
 // FileSyncRenameMessage 同步过程中文件重命名的消息结构
 type FileSyncRenameMessage struct {

--- a/internal/dto/note_dto_ws.go
+++ b/internal/dto/note_dto_ws.go
@@ -62,3 +62,16 @@ type NoteSyncDeleteMessage struct {
 	Size             int64  `json:"size" form:"size" example:"1024"`                       // File size // 文件大小
 	UpdatedTimestamp int64  `json:"lastTime" form:"updatedTimestamp" example:"1700000000"` // Record update timestamp // 记录更新时间戳
 }
+
+// NoteModifyAckMessage note modify operation ACK, sent back to sender after server processes NoteModify
+// NoteModifyAckMessage 笔记修改操作 ACK，服务端处理完 NoteModify 后回发给发送方
+type NoteModifyAckMessage struct {
+	LastTime int64  `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
+	Path     string `json:"path"`     // Note path // 笔记路径
+}
+
+// NoteRenameAckMessage note rename operation ACK, sent back to sender after server processes NoteRename
+// NoteRenameAckMessage 笔记重命名操作 ACK，服务端处理完 NoteRename 后回发给发送方
+type NoteRenameAckMessage struct {
+	LastTime int64 `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
+}

--- a/internal/dto/note_dto_ws.go
+++ b/internal/dto/note_dto_ws.go
@@ -73,7 +73,8 @@ type NoteModifyAckMessage struct {
 // NoteRenameAckMessage note rename operation ACK, sent back to sender after server processes NoteRename
 // NoteRenameAckMessage 笔记重命名操作 ACK，服务端处理完 NoteRename 后回发给发送方
 type NoteRenameAckMessage struct {
-	LastTime int64 `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
+	LastTime int64  `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
+	Path     string `json:"path"`     // New note path after rename // 重命名后的笔记新路径
 }
 
 // NoteDeleteAckMessage note delete operation ACK, sent back to sender after server processes NoteDelete

--- a/internal/dto/note_dto_ws.go
+++ b/internal/dto/note_dto_ws.go
@@ -75,3 +75,10 @@ type NoteModifyAckMessage struct {
 type NoteRenameAckMessage struct {
 	LastTime int64 `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
 }
+
+// NoteDeleteAckMessage note delete operation ACK, sent back to sender after server processes NoteDelete
+// NoteDeleteAckMessage 笔记删除操作 ACK，服务端处理完 NoteDelete 后回发给发送方
+type NoteDeleteAckMessage struct {
+	LastTime int64  `json:"lastTime"` // Server write timestamp // 服务端写入时间戳
+	Path     string `json:"path"`     // Note path // 笔记路径
+}

--- a/internal/dto/ws_dto.go
+++ b/internal/dto/ws_dto.go
@@ -136,6 +136,9 @@ const (
 	// NoteRenameAck note rename operation ack
 	// NoteRenameAck 笔记重命名操作 ack
 	NoteRenameAck WebSocketSendAction = "NoteRenameAck"
+	// NoteDeleteAck note delete operation ack
+	// NoteDeleteAck 笔记删除操作 ack
+	NoteDeleteAck WebSocketSendAction = "NoteDeleteAck"
 
 	// ---------------- File ----------------
 
@@ -166,6 +169,9 @@ const (
 	// FileUploadAck file upload complete ack
 	// FileUploadAck 文件上传完成 ack
 	FileUploadAck WebSocketSendAction = "FileUploadAck"
+	// FileDeleteAck file delete operation ack
+	// FileDeleteAck 文件删除操作 ack
+	FileDeleteAck WebSocketSendAction = "FileDeleteAck"
 
 	// ---------------- Setting ----------------
 

--- a/internal/dto/ws_dto.go
+++ b/internal/dto/ws_dto.go
@@ -130,6 +130,12 @@ const (
 	// NoteSyncNeedPush indicates client needs to push note content
 	// NoteSyncNeedPush 表示客户端需要推送笔记内容
 	NoteSyncNeedPush WebSocketSendAction = "NoteSyncNeedPush"
+	// NoteModifyAck note modify operation ack
+	// NoteModifyAck 笔记修改操作 ack
+	NoteModifyAck WebSocketSendAction = "NoteModifyAck"
+	// NoteRenameAck note rename operation ack
+	// NoteRenameAck 笔记重命名操作 ack
+	NoteRenameAck WebSocketSendAction = "NoteRenameAck"
 
 	// ---------------- File ----------------
 

--- a/internal/routers/websocket_router/ws_file.go
+++ b/internal/routers/websocket_router/ws_file.go
@@ -453,6 +453,7 @@ func (h *FileWSHandler) FileRename(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 	// 回复发送方携带服务端时间戳的 ack，让客户端可以更新 lastFileSyncTime
 	c.ToResponse(code.Success.WithData(dto.FileRenameAckMessage{
 		LastTime: newFile.UpdatedTimestamp,
+		Path:     newFile.Path,
 	}), string(dto.FileRenameAck))
 
 	c.BroadcastResponse(code.Success.WithData(

--- a/internal/routers/websocket_router/ws_file.go
+++ b/internal/routers/websocket_router/ws_file.go
@@ -412,7 +412,10 @@ func (h *FileWSHandler) FileDelete(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 		return
 	}
 
-	c.ToResponse(code.Success)
+	c.ToResponse(code.Success.WithData(dto.FileDeleteAckMessage{
+		LastTime: fileSvc.UpdatedTimestamp,
+		Path:     fileSvc.Path,
+	}).WithVault(params.Vault), string(dto.FileDeleteAck))
 
 	// Broadcast file deletion message
 	// 广播文件删除消息

--- a/internal/routers/websocket_router/ws_note.go
+++ b/internal/routers/websocket_router/ws_note.go
@@ -581,6 +581,7 @@ func (h *NoteWSHandler) NoteRename(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 	// Notify sender of successful rename with lastTime for client FIFO queue hashManager update
 	c.ToResponse(code.Success.WithData(dto.NoteRenameAckMessage{
 		LastTime: newNote.UpdatedTimestamp,
+		Path:     newNote.Path,
 	}).WithVault(params.Vault), string(dto.NoteRenameAck))
 	c.BroadcastResponse(code.Success.WithData(
 		dto.NoteSyncRenameMessage{

--- a/internal/routers/websocket_router/ws_note.go
+++ b/internal/routers/websocket_router/ws_note.go
@@ -351,10 +351,12 @@ func (h *NoteWSHandler) NoteModify(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 			return
 		}
 
-		// Notify all clients to update mtime
-		// 通知所有客户端更新mtime
-
-		c.ToResponse(code.Success)
+		// 通知发送方上传已确认，携带 lastTime 和 path 供客户端更新 hashManager
+		// Notify sender of successful write with lastTime and path for client hashManager update
+		c.ToResponse(code.Success.WithData(dto.NoteModifyAckMessage{
+			LastTime: note.UpdatedTimestamp,
+			Path:     note.Path,
+		}).WithVault(params.Vault), string(dto.NoteModifyAck))
 		c.BroadcastResponse(code.Success.WithData(
 			dto.NoteSyncModifyMessage{
 				Path:             note.Path,
@@ -558,7 +560,11 @@ func (h *NoteWSHandler) NoteRename(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 		return
 	}
 
-	c.ToResponse(code.Success)
+	// 通知发送方重命名已确认，携带 lastTime 供客户端 FIFO 队列更新 hashManager
+	// Notify sender of successful rename with lastTime for client FIFO queue hashManager update
+	c.ToResponse(code.Success.WithData(dto.NoteRenameAckMessage{
+		LastTime: newNote.UpdatedTimestamp,
+	}).WithVault(params.Vault), string(dto.NoteRenameAck))
 	c.BroadcastResponse(code.Success.WithData(
 		dto.NoteSyncRenameMessage{
 			Path:             newNote.Path,

--- a/internal/routers/websocket_router/ws_note.go
+++ b/internal/routers/websocket_router/ws_note.go
@@ -116,7 +116,12 @@ func (h *NoteWSHandler) NoteModify(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 					zap.Int64(logger.FieldUID, c.User.UID),
 					zap.String(logger.FieldPath, params.Path),
 					zap.String("contentHash", contentHash))
-				c.ToResponse(code.SuccessNoUpdate)
+				// 内容已存在，仍需发 NoteModifyAck 以便客户端消费 pendingNoteModifies，避免无限重传
+				// Content already exists; still send NoteModifyAck so client can consume pendingNoteModifies and avoid infinite re-upload
+				c.ToResponse(code.Success.WithData(dto.NoteModifyAckMessage{
+					LastTime: nodeCheck.UpdatedTimestamp,
+					Path:     params.Path,
+				}).WithVault(params.Vault), string(dto.NoteModifyAck))
 				return
 			}
 
@@ -383,7 +388,16 @@ func (h *NoteWSHandler) NoteModify(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 		).WithVault(params.Vault), dto.NoteSyncMtime)
 		return
 	default:
-		c.ToResponse(code.SuccessNoUpdate)
+		// SuccessNoUpdate 场景也需发 NoteModifyAck，避免客户端 pendingNoteModifies 条目泄漏导致无限重传
+		// SuccessNoUpdate also needs NoteModifyAck to prevent client pendingNoteModifies leak causing infinite re-upload
+		if nodeCheck != nil {
+			c.ToResponse(code.Success.WithData(dto.NoteModifyAckMessage{
+				LastTime: nodeCheck.UpdatedTimestamp,
+				Path:     params.Path,
+			}).WithVault(params.Vault), string(dto.NoteModifyAck))
+		} else {
+			c.ToResponse(code.SuccessNoUpdate)
+		}
 		return
 	}
 }

--- a/internal/routers/websocket_router/ws_note.go
+++ b/internal/routers/websocket_router/ws_note.go
@@ -524,7 +524,10 @@ func (h *NoteWSHandler) NoteDelete(c *pkgapp.WebsocketClient, msg *pkgapp.WebSoc
 		return
 	}
 
-	c.ToResponse(code.Success)
+	c.ToResponse(code.Success.WithData(dto.NoteDeleteAckMessage{
+		LastTime: note.UpdatedTimestamp,
+		Path:     note.Path,
+	}).WithVault(params.Vault), string(dto.NoteDeleteAck))
 	c.BroadcastResponse(code.Success.WithData(
 		dto.NoteSyncDeleteMessage{
 			Path:             note.Path,


### PR DESCRIPTION
## 概述

本 PR 为 `NoteModify`、`NoteRename`、`NoteDelete`、`FileDelete` 四个 WebSocket 处理器新增服务端 ACK 响应，使客户端能够在服务端确认操作后再更新 `hashManager`，修复断线场景下的同步状态分叉问题。

### 背景：竞态问题

客户端通过 `hashManager`（基于 localStorage 的 Map）记录哪些文件已同步到服务端。此前，hash 更新发生在 **on-send 回调**中——即消息进入 TCP 发送缓冲区时——而非服务端实际处理完成后。

若消息发出后、服务端收到前 TCP 连接中断，客户端的 hash 状态将与服务端实际状态发生分叉：

- **NoteModify / NoteRename 中断**：文件在客户端 hashManager 中显示"已同步"，增量过滤器跳过该文件，修改内容永远不会重传。
- **NoteDelete / FileDelete 中断**：hash 已从 hashManager 删除，重连后路径既不在本地也不在 hashManager，不会进入 `delNotes`，服务端文件成为永久孤儿。

### 解决方案

为每个变更操作新增类型化 ACK 响应。客户端推迟所有 hashManager 写入，直到收到对应 ACK。若连接在 ACK 到达前中断，旧的 hash 状态得以保留，操作在重连后自然重试。

---

## 改动说明

### 新增 NoteModifyAck 和 NoteRenameAck（`335bef2`）

- **`internal/dto/note_dto_ws.go`**：新增 `NoteModifyAckMessage{LastTime, Path}` 和 `NoteRenameAckMessage{LastTime}` 结构体。
- **`internal/dto/ws_dto.go`**：新增 `NoteModifyAck` 和 `NoteRenameAck` Action 常量。
- **`internal/routers/websocket_router/ws_note.go`**：`NoteModify` 和 `NoteRename` handler 的 `c.ToResponse(code.Success)` 替换为携带 `lastTime` 和 `path` 的类型化 ACK 响应。

### 修复 SuccessNoUpdate 分支导致无限重传（`29154ce`）

`NoteModify` 处理器中有两条代码路径返回 `SuccessNoUpdate`，不携带 Action 类型，客户端无法路由到任何 handler。配合客户端新增的 `pendingNoteModifies` 机制，未被消费的 pending 条目会导致增量过滤器永远无法跳过该文件，形成无限重传循环。

涉及的两个分支：
1. `case "UpdateContent", "Create"` 内部：当 `serverHash == contentHash` 时（竞态：另一设备已上传相同内容，或用户修改后恢复导致 hash 回退但 mtime 变化）。
2. `default` 分支：`UpdateCheck` 返回 `""`（hash 和 mtime 均已与服务端一致）。

修复方式：将两个分支的 `SuccessNoUpdate` 替换为 `NoteModifyAck`，客户端 `receiveNoteModifyAck` 正确消费 pending 条目并提交 hash。

### 新增 NoteDeleteAck 和 FileDeleteAck（`84f22aa`）

- **`internal/dto/note_dto_ws.go`**：新增 `NoteDeleteAckMessage{LastTime, Path}`。
- **`internal/dto/file_dto_ws.go`**：新增 `FileDeleteAckMessage{LastTime, Path}`。
- **`internal/dto/ws_dto.go`**：新增 `NoteDeleteAck` 和 `FileDeleteAck` Action 常量。
- **`internal/routers/websocket_router/ws_note.go`**：`NoteDelete` handler 改为回复携带 `note.UpdatedTimestamp` 和 `note.Path` 的 `NoteDeleteAck`。广播给其他设备的 `BroadcastResponse`（NoteSyncDelete）保持不变。
- **`internal/routers/websocket_router/ws_file.go`**：`FileDelete` handler 对称修改，回复 `FileDeleteAck`。

---

## 协议兼容性

所有改动均为增量新增。ACK 消息仅通过 `c.ToResponse` 发送给发起操作的客户端，不广播。不识别新 Action 类型的旧客户端会直接忽略，不受影响。

## 测试计划

- [ ] 正常流程：修改/重命名/删除笔记，确认服务端日志输出 ACK，客户端 hash 正确更新
- [ ] 断连模拟：操作进行中停止服务端，重启后确认操作被正确重试并收敛
- [ ] 多设备：设备 A 删除笔记，设备 B 离线，双方重连后确认服务端文件被正确删除，无孤儿残留
- [ ] SuccessNoUpdate 分支：上传与服务端 hash 已一致的笔记，确认不触发无限重传