### PR TITLE
fix: Git 同步支持 HTTP_PROXY/HTTPS_PROXY 环境变量 (#240)

### DIFF
--- a/internal/service/git_sync_service.go
+++ b/internal/service/git_sync_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -556,6 +557,7 @@ func (s *gitSyncService) doSync(ctx context.Context, conf *domain.GitSyncConfig)
 		r, err = git.PlainClone(wsPath, false, &git.CloneOptions{
 			URL:           conf.RepoURL,
 			Auth:          auth,
+			Proxy:         http.ProxyFromEnvironment,
 			ReferenceName: plumbing.NewBranchReferenceName(conf.Branch),
 			SingleBranch:  true,
 			Depth:         1,
@@ -597,6 +599,7 @@ func (s *gitSyncService) doSync(ctx context.Context, conf *domain.GitSyncConfig)
 	s.logger.Info("Pulling latest changes", zap.Int64("configId", conf.ID))
 	err = wt.Pull(&git.PullOptions{
 		Auth:          auth,
+		Proxy:         http.ProxyFromEnvironment,
 		ReferenceName: plumbing.NewBranchReferenceName(conf.Branch),
 		SingleBranch:  true,
 		Force:         true,
@@ -659,7 +662,8 @@ func (s *gitSyncService) doSync(ctx context.Context, conf *domain.GitSyncConfig)
 
 	s.logger.Info("Pushing changes", zap.Int64("configId", conf.ID))
 	err = r.Push(&git.PushOptions{
-		Auth: auth,
+		Auth:  auth,
+		Proxy: http.ProxyFromEnvironment,
 	})
 	if err != nil {
 		return fmt.Errorf("git push failed: %w", err)


### PR DESCRIPTION
## 问题描述

使用 go-git v5 库进行 Git 仓库备份时，`go-git` **不会自动读取** `HTTP_PROXY`/`HTTPS_PROXY` 环境变量。

这导致：
- Docker 容器内配置了代理（`HTTP_PROXY`/`HTTPS_PROXY`），`curl` 能正常访问 GitHub，但 Git 备份一直失败
- 国内用户在路由器级代理环境下，容器内的 Git 操作因 DNS 污染无法连接 GitHub

## 根因

go-git 的 `CloneOptions`/`PullOptions`/`PushOptions` 有 `Proxy` 字段，但代码中未设置，默认值为 nil（直连）。

## 修复方案

为三个 Git 操作选项统一注入 `http.ProxyFromEnvironment`，使其自动读取系统代理环境变量：
- `HTTP_PROXY` / `http_proxy`
- `HTTPS_PROXY` / `https_proxy`  
- `NO_PROXY` / `no_proxy`

用户只需在 Docker 环境变量或 `entrypoint.sh` 中配置即可生效，无需代码改动。

Refs #240