### PR TITLE
fix: PostgreSQL 下 FTS 索引 token 字段 varchar(255) 长度不足 (#231)

### DIFF
--- a/internal/dao/note_fts_repository.go
+++ b/internal/dao/note_fts_repository.go
@@ -40,7 +40,7 @@ func (r *noteFTSRepository) ensureFTSTable(uid int64) *gorm.DB {
 
 	// Use onceKeys to ensure it is created only once
 	// 使用 onceKeys 确保只创建一次
-	onceKey := key + "#note_fts_v3"
+	onceKey := key + "#note_fts_v4"
 	if _, loaded := r.dao.onceKeys.LoadOrStore(onceKey, true); !loaded {
 		_ = model.CreateNoteFTSTable(db)
 	}

--- a/internal/model/note_fts.go
+++ b/internal/model/note_fts.go
@@ -6,7 +6,7 @@ import (
 )
 
 // FTS 表版本号，修改此值会触发重建索引
-const NoteFTSVersion = 3
+const NoteFTSVersion = 4
 
 // NoteFTS 存储笔记全文搜索的快照数据
 type NoteFTS struct {
@@ -24,7 +24,7 @@ func (*NoteFTS) TableName() string {
 type NoteFTSToken struct {
 	ID     int64  `gorm:"column:id;primaryKey;autoIncrement"`
 	NoteID int64  `gorm:"column:note_id;index:idx_fts_note_id;index:idx_fts_token_note_id,priority:2"`
-	Token  string `gorm:"column:token;type:varchar(255);index:idx_fts_token;index:idx_fts_token_note_id,priority:1"`
+	Token  string `gorm:"column:token;type:text;index:idx_fts_token;index:idx_fts_token_note_id,priority:1"`
 }
 
 func (*NoteFTSToken) TableName() string {


### PR DESCRIPTION
## 问题

使用 PostgreSQL 作为数据库时，全文搜索功能报错：

```
ERROR: value too long for type character varying(255)
STATEMENT: INSERT INTO "note_fts_token" ("note_id","token") VALUES (...)
```

相关 Issue: #231

## 根因分析

`internal/model/note_fts.go` 中 `NoteFTSToken` 结构体的 `Token` 字段定义为 `type:varchar(255)`。

PostgreSQL 严格执行 varchar 长度限制，当分词结果中的 token 超过 255 字符时，INSERT 操作直接报错。SQLite 不强制 varchar 长度，因此此 bug 仅在 PostgreSQL 下复现。

## 修复内容

1. **token 字段类型改为 `text`** — 取消长度限制，PostgreSQL 和 SQLite 行为一致
2. **FTS 表版本号 3→4** — 触发自动 Drop + 重建索引，确保已有 PG 用户的表结构也被修复
3. **同步更新 onceKey 版本标识** — `note_fts_repository.go` 中 `#note_fts_v3` → `#note_fts_v4`

## 影响范围

- ✅ 修复 PostgreSQL 用户全文搜索报错
- ✅ 已有 PG 用户升级后自动重建索引（版本号机制）
- ✅ SQLite 用户无影响（text 和 varchar 行为相同）
- ⚠️ 升级后首次启动会重建 FTS 索引，大型笔记库可能需要几秒到几十秒