### PR TITLE
fix: 修复多端增量同步时间窗口与广播消息完整性问题

### DIFF
--- a/internal/dto/file_dto_ws.go
+++ b/internal/dto/file_dto_ws.go
@@ -26,6 +26,7 @@ type FileSyncEndMessage struct {
 // FileSyncUploadMessage 定义服务端通知客户端需要上传文件的消息结构
 type FileSyncUploadMessage struct {
 	Path      string `json:"path" example:"Image.png"`        // File path // 文件路径
+	PathHash  string `json:"pathHash" example:"fhash123"`     // Path hash // 路径哈希值
 	SessionID string `json:"sessionId" example:"sess_123456"` // Session ID // 会话 ID
 	ChunkSize int64  `json:"chunkSize" example:"1048576"`     // Chunk size // 分块大小
 }

--- a/internal/dto/folder_dto_ws.go
+++ b/internal/dto/folder_dto_ws.go
@@ -11,21 +11,23 @@ type FolderSyncEndMessage struct {
 // FolderSyncRenameMessage message structure for folder rename during sync
 // FolderSyncRenameMessage 同步过程中文件夹重命名的消息结构
 type FolderSyncRenameMessage struct {
-	Path        string `json:"path" form:"path" binding:"required" example:"NewFolder"` // New path // 新路径
-	PathHash    string `json:"pathHash" form:"pathHash" example:"nfhash123"`            // New path hash // 新路径哈希
-	Ctime       int64  `json:"ctime" form:"ctime" example:"1700000000"`                 // Creation timestamp // 创建时间戳
-	Mtime       int64  `json:"mtime" form:"mtime" example:"1700000000"`                 // Modification timestamp // 修改时间戳
-	OldPath     string `json:"oldPath" form:"oldPath" example:"OldFolder"`              // Old path // 旧路径
-	OldPathHash string `json:"oldPathHash" form:"oldPathHash" example:"ofhash456"`      // Old path hash // 旧路径哈希
+	Path             string `json:"path" form:"path" binding:"required" example:"NewFolder"` // New path // 新路径
+	PathHash         string `json:"pathHash" form:"pathHash" example:"nfhash123"`            // New path hash // 新路径哈希
+	Ctime            int64  `json:"ctime" form:"ctime" example:"1700000000"`                 // Creation timestamp // 创建时间戳
+	Mtime            int64  `json:"mtime" form:"mtime" example:"1700000000"`                 // Modification timestamp // 修改时间戳
+	OldPath          string `json:"oldPath" form:"oldPath" example:"OldFolder"`              // Old path // 旧路径
+	OldPathHash      string `json:"oldPathHash" form:"oldPathHash" example:"ofhash456"`      // Old path hash // 旧路径哈希
+	UpdatedTimestamp int64  `json:"lastTime" form:"updatedTimestamp" example:"1700000000"`   // Record update timestamp // 记录更新时间戳
 }
 
 // FolderSyncDeleteMessage message structure for folder deletion during sync
 // FolderSyncDeleteMessage 同步期间文件夹删除的消息结构
 type FolderSyncDeleteMessage struct {
-	Path     string `json:"path" form:"path" example:"DeletedFolder"`     // Folder path // 文件夹路径
-	PathHash string `json:"pathHash" form:"pathHash" example:"dfhash789"` // Path hash // 路径哈希值
-	Ctime    int64  `json:"ctime" form:"ctime" example:"1700000000"`      // Creation timestamp // 创建时间戳
-	Mtime    int64  `json:"mtime" form:"mtime" example:"1700000000"`      // Modification timestamp // 修改时间戳
+	Path             string `json:"path" form:"path" example:"DeletedFolder"`               // Folder path // 文件夹路径
+	PathHash         string `json:"pathHash" form:"pathHash" example:"dfhash789"`           // Path hash // 路径哈希值
+	Ctime            int64  `json:"ctime" form:"ctime" example:"1700000000"`                // Creation timestamp // 创建时间戳
+	Mtime            int64  `json:"mtime" form:"mtime" example:"1700000000"`                // Modification timestamp // 修改时间戳
+	UpdatedTimestamp int64  `json:"lastTime" form:"updatedTimestamp" example:"1700000000"`  // Record update timestamp // 记录更新时间戳
 }
 
 // FolderSyncModifyMessage message content for folder modification or creation during sync

--- a/internal/routers/websocket_router/ws_file.go
+++ b/internal/routers/websocket_router/ws_file.go
@@ -573,6 +573,11 @@ func (h *FileWSHandler) FileSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 	// Get list of changed files after last sync
 	// 获取最后一次同步后的变更文件列表
 	fileService := h.App.GetFileService(c.ClientType, c.ClientName, c.ClientVersion)
+
+	// Record sync start time before querying to avoid missing writes that occur during query processing.
+	// 查询前记录同步开始时间，防止查询处理期间的写入被遗漏（经典增量同步快照时间戳方案）。
+	syncStartTime := timex.Now().UnixMilli()
+
 	list, err := fileService.ListByLastTime(ctx, c.User.UID, params)
 
 	if err != nil {
@@ -832,11 +837,10 @@ func (h *FileWSHandler) FileSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 		}
 	}
 
-	// Use current time as lastTime regardless of whether list is empty,
-	// ensuring lastTime > all returned files' updated_timestamp (mirrors FolderSync design)
-	// 无论 list 是否为空，均取当前时间作为 lastTime，
-	// 确保 lastTime > 所有返回文件的 updated_timestamp（与 FolderSync 保持一致）
-	lastTime = timex.Now().UnixMilli()
+	// Use syncStartTime (recorded before query) as lastTime to prevent writes that occurred
+	// during query processing from being permanently missed on the next incremental sync.
+	// 使用查询前记录的 syncStartTime 作为 lastTime，防止查询处理期间的写入在下次增量同步时被永久遗漏。
+	lastTime = syncStartTime
 	// Handle files that exist on client but not synced on server (request client upload)
 	// 处理客户端存在但服务端未同步的文件（请求客户端上传）
 	if len(cFilesKeys) > 0 {

--- a/internal/routers/websocket_router/ws_file.go
+++ b/internal/routers/websocket_router/ws_file.go
@@ -172,6 +172,7 @@ func (h *FileWSHandler) FileUploadCheck(c *pkgapp.WebsocketClient, msg *pkgapp.W
 		c.ToResponse(code.Success.WithData(
 			dto.FileSyncUploadMessage{
 				Path:      session.Path,
+				PathHash:  session.PathHash,
 				SessionID: session.ID,
 				ChunkSize: session.ChunkSize,
 			},
@@ -647,11 +648,12 @@ func (h *FileWSHandler) FileSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 				// 将删除消息广播给其他客户端
 				c.BroadcastResponse(code.Success.WithData(
 					dto.FileSyncDeleteMessage{
-						Path:     fileSvc.Path,
-						PathHash: fileSvc.PathHash,
-						Ctime:    fileSvc.Ctime,
-						Mtime:    fileSvc.Mtime,
-						Size:     fileSvc.Size,
+						Path:             fileSvc.Path,
+						PathHash:         fileSvc.PathHash,
+						Ctime:            fileSvc.Ctime,
+						Mtime:            fileSvc.Mtime,
+						Size:             fileSvc.Size,
+						UpdatedTimestamp: fileSvc.UpdatedTimestamp,
 					},
 				).WithVault(params.Vault), true, dto.FileSyncDelete)
 
@@ -671,11 +673,12 @@ func (h *FileWSHandler) FileSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 				// 使用现有信息(Path/PathHash)广播删除
 				c.BroadcastResponse(code.Success.WithData(
 					dto.FileSyncDeleteMessage{
-						Path:     delFile.Path,
-						PathHash: delFile.PathHash,
-						Ctime:    0,
-						Mtime:    0,
-						Size:     0,
+						Path:             delFile.Path,
+						PathHash:         delFile.PathHash,
+						Ctime:            0,
+						Mtime:            0,
+						Size:             0,
+						UpdatedTimestamp: 0,
 					},
 				).WithVault(params.Vault), true, dto.FileSyncDelete)
 			}
@@ -794,6 +797,7 @@ func (h *FileWSHandler) FileSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 							Action: dto.FileUpload,
 							Data: dto.FileSyncUploadMessage{
 								Path:      session.Path,
+								PathHash:  session.PathHash,
 								SessionID: session.ID,
 								ChunkSize: session.ChunkSize,
 							},
@@ -859,6 +863,7 @@ func (h *FileWSHandler) FileSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 				Action: dto.FileUpload,
 				Data: dto.FileSyncUploadMessage{
 					Path:      session.Path,
+					PathHash:  session.PathHash,
 					SessionID: session.ID,
 					ChunkSize: session.ChunkSize,
 				},

--- a/internal/routers/websocket_router/ws_folder.go
+++ b/internal/routers/websocket_router/ws_folder.go
@@ -80,10 +80,11 @@ func (h *FolderWSHandler) FolderSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebS
 				// Broadcast deletion to other clients
 				c.BroadcastResponse(code.Success.WithData(
 					dto.FolderSyncDeleteMessage{
-						Path:     folder.Path,
-						PathHash: folder.PathHash,
-						Ctime:    folder.Ctime,
-						Mtime:    folder.Mtime,
+						Path:             folder.Path,
+						PathHash:         folder.PathHash,
+						Ctime:            folder.Ctime,
+						Mtime:            folder.Mtime,
+						UpdatedTimestamp: folder.UpdatedTimestamp,
 					},
 				).WithVault(params.Vault).WithContext(params.Context), true, dto.FolderSyncDelete)
 			} else {
@@ -95,10 +96,11 @@ func (h *FolderWSHandler) FolderSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebS
 				// Broadcast deletion with available info
 				c.BroadcastResponse(code.Success.WithData(
 					dto.FolderSyncDeleteMessage{
-						Path:     delFolder.Path,
-						PathHash: delFolder.PathHash,
-						Ctime:    0,
-						Mtime:    0,
+						Path:             delFolder.Path,
+						PathHash:         delFolder.PathHash,
+						Ctime:            0,
+						Mtime:            0,
+						UpdatedTimestamp: 0,
 					},
 				).WithVault(params.Vault).WithContext(params.Context), true, dto.FolderSyncDelete)
 			}
@@ -161,10 +163,11 @@ func (h *FolderWSHandler) FolderSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebS
 			messageQueue = append(messageQueue, dto.WSQueuedMessage{
 				Action: dto.FolderSyncDelete,
 				Data: dto.FolderSyncDeleteMessage{
-					Path:     folder.Path,
-					PathHash: folder.PathHash,
-					Ctime:    folder.Ctime,
-					Mtime:    folder.Mtime,
+					Path:             folder.Path,
+					PathHash:         folder.PathHash,
+					Ctime:            folder.Ctime,
+					Mtime:            folder.Mtime,
+					UpdatedTimestamp: folder.UpdatedTimestamp,
 				},
 			})
 			needDeleteCount++
@@ -286,10 +289,11 @@ func (h *FolderWSHandler) FolderDelete(c *pkgapp.WebsocketClient, msg *pkgapp.We
 	}), string(dto.FolderDeleteAck))
 	c.BroadcastResponse(code.Success.WithData(
 		dto.FolderSyncDeleteMessage{
-			Path:     folder.Path,
-			PathHash: folder.PathHash,
-			Ctime:    folder.Ctime,
-			Mtime:    folder.Mtime,
+			Path:             folder.Path,
+			PathHash:         folder.PathHash,
+			Ctime:            folder.Ctime,
+			Mtime:            folder.Mtime,
+			UpdatedTimestamp: folder.UpdatedTimestamp,
 		},
 	).WithVault(params.Vault), true, dto.FolderSyncDelete)
 }
@@ -333,12 +337,13 @@ func (h *FolderWSHandler) FolderRename(c *pkgapp.WebsocketClient, msg *pkgapp.We
 	}
 
 	c.BroadcastResponse(code.Success.WithData(dto.FolderSyncRenameMessage{
-		Path:        newFolder.Path,
-		PathHash:    newFolder.PathHash,
-		Ctime:       newFolder.Ctime,
-		Mtime:       newFolder.Mtime,
-		OldPath:     oldFolder.Path,
-		OldPathHash: oldFolder.PathHash,
+		Path:             newFolder.Path,
+		PathHash:         newFolder.PathHash,
+		Ctime:            newFolder.Ctime,
+		Mtime:            newFolder.Mtime,
+		OldPath:          oldFolder.Path,
+		OldPathHash:      oldFolder.PathHash,
+		UpdatedTimestamp: newFolder.UpdatedTimestamp,
 	}).WithVault(params.Vault), true, dto.FolderSyncRename)
 
 }

--- a/internal/routers/websocket_router/ws_folder.go
+++ b/internal/routers/websocket_router/ws_folder.go
@@ -139,6 +139,12 @@ func (h *FolderWSHandler) FolderSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebS
 	}
 
 	// Get updated folders from server
+	// 获取服务端更新的文件夹列表
+
+	// Record sync start time before querying to avoid missing writes that occur during query processing.
+	// 查询前记录同步开始时间，防止查询处理期间的写入被遗漏（经典增量同步快照时间戳方案）。
+	syncStartTime := timex.Now().UnixMilli()
+
 	list, err := folderSvc.ListByUpdatedTimestamp(ctx, uid, params.Vault, params.LastTime)
 	if err != nil {
 		h.respondError(c, code.ErrorFolderListFailed, err, "websocket_router.folder.FolderSync.ListByUpdatedTimestamp")
@@ -210,7 +216,9 @@ func (h *FolderWSHandler) FolderSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebS
 	// Send FolderSyncEnd message
 	// 发送 FolderSyncEnd 消息
 	c.ToResponse(code.Success.WithData(&dto.FolderSyncEndMessage{
-		LastTime:        timex.Now().UnixMilli(),
+		// Use syncStartTime (recorded before query) to prevent writes during query processing from being missed.
+		// 使用查询前记录的 syncStartTime，防止查询处理期间的写入在下次增量同步时被永久遗漏。
+		LastTime:        syncStartTime,
 		NeedModifyCount: needModifyCount,
 		NeedDeleteCount: needDeleteCount,
 	}).WithContext(params.Context), dto.FolderSyncEnd)

--- a/internal/routers/websocket_router/ws_note.go
+++ b/internal/routers/websocket_router/ws_note.go
@@ -677,6 +677,10 @@ func (h *NoteWSHandler) NoteSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 	// 检查并创建仓库，内部使用SF合并并发请求, 避免重复创建问题
 	h.App.VaultService.GetOrCreate(ctx, c.User.UID, params.Vault)
 
+	// Record sync start time before querying to avoid missing writes that occur during query processing.
+	// 查询前记录同步开始时间，防止查询处理期间的写入被遗漏（经典增量同步快照时间戳方案）。
+	syncStartTime := timex.Now().UnixMilli()
+
 	list, err := noteSvc.ListByLastTime(ctx, c.User.UID, params)
 
 	if err != nil {
@@ -967,11 +971,10 @@ func (h *NoteWSHandler) NoteSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 		}
 	}
 
-	// Use current time as lastTime regardless of whether list is empty,
-	// ensuring lastTime > all returned notes' updated_timestamp (mirrors FolderSync design)
-	// 无论 list 是否为空，均取当前时间作为 lastTime，
-	// 确保 lastTime > 所有返回笔记的 updated_timestamp（与 FolderSync 保持一致）
-	lastTime = timex.Now().UnixMilli()
+	// Use syncStartTime (recorded before query) as lastTime to prevent writes that occurred
+	// during query processing from being permanently missed on the next incremental sync.
+	// 使用查询前记录的 syncStartTime 作为 lastTime，防止查询处理期间的写入在下次增量同步时被永久遗漏。
+	lastTime = syncStartTime
 	if len(cNotesKeys) > 0 {
 		for pathHash := range cNotesKeys {
 			note := cNotes[pathHash]

--- a/internal/routers/websocket_router/ws_note.go
+++ b/internal/routers/websocket_router/ws_note.go
@@ -748,11 +748,12 @@ func (h *NoteWSHandler) NoteSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 				// 将删除消息广播给其他客户端
 				c.BroadcastResponse(code.Success.WithData(
 					dto.NoteSyncDeleteMessage{
-						Path:     note.Path,
-						PathHash: note.PathHash,
-						Ctime:    note.Ctime,
-						Mtime:    note.Mtime,
-						Size:     note.Size,
+						Path:             note.Path,
+						PathHash:         note.PathHash,
+						Ctime:            note.Ctime,
+						Mtime:            note.Mtime,
+						Size:             note.Size,
+						UpdatedTimestamp: note.UpdatedTimestamp,
 					},
 				).WithVault(params.Vault), true, dto.NoteSyncDelete)
 
@@ -772,11 +773,12 @@ func (h *NoteWSHandler) NoteSync(c *pkgapp.WebsocketClient, msg *pkgapp.WebSocke
 				// 使用现有信息(Path/PathHash)广播删除
 				c.BroadcastResponse(code.Success.WithData(
 					dto.NoteSyncDeleteMessage{
-						Path:     delNote.Path,
-						PathHash: delNote.PathHash,
-						Ctime:    0,
-						Mtime:    0,
-						Size:     0,
+						Path:             delNote.Path,
+						PathHash:         delNote.PathHash,
+						Ctime:            0,
+						Mtime:            0,
+						Size:             0,
+						UpdatedTimestamp: 0,
 					},
 				).WithVault(params.Vault), true, dto.NoteSyncDelete)
 			}

--- a/internal/routers/websocket_router/ws_setting.go
+++ b/internal/routers/websocket_router/ws_setting.go
@@ -198,6 +198,10 @@ func (h *SettingWSHandler) SettingSync(c *pkgapp.WebsocketClient, msg *pkgapp.We
 
 	settingSvc := h.App.GetSettingService(c.ClientType, c.ClientName, c.ClientVersion)
 
+	// Record sync start time before querying to avoid missing writes that occur during query processing.
+	// 查询前记录同步开始时间，防止查询处理期间的写入被遗漏（经典增量同步快照时间戳方案）。
+	syncStartTime := timex.Now().UnixMilli()
+
 	list, err := settingSvc.Sync(ctx, c.User.UID, params)
 	if err != nil {
 		h.respondError(c, code.ErrorSettingListFailed, err, "websocket_router.setting.SettingSync.Sync")
@@ -328,9 +332,6 @@ func (h *SettingWSHandler) SettingSync(c *pkgapp.WebsocketClient, msg *pkgapp.We
 			continue
 		}
 
-		if s.UpdatedTimestamp >= lastTime {
-			lastTime = s.UpdatedTimestamp
-		}
 		if s.Action == "delete" {
 			// Server already deleted, notify client to delete (regardless of whether client has it)
 			// 服务端已经删除，通知客户端删除（不再检查客户端是否存在）
@@ -444,9 +445,10 @@ func (h *SettingWSHandler) SettingSync(c *pkgapp.WebsocketClient, msg *pkgapp.We
 		}
 	}
 
-	if list == nil {
-		lastTime = timex.Now().UnixMilli()
-	}
+	// Use syncStartTime (recorded before query) as lastTime to prevent writes that occurred
+	// during query processing from being permanently missed on the next incremental sync.
+	// 使用查询前记录的 syncStartTime 作为 lastTime，防止查询处理期间的写入在下次增量同步时被永久遗漏。
+	lastTime = syncStartTime
 	for pathHash := range cSettingsKeys {
 		s := cSettings[pathHash]
 		// Add message to queue instead of sending immediately

--- a/pkg/app/websocket.go
+++ b/pkg/app/websocket.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -263,6 +264,7 @@ type WebsocketClient struct {
 	DiffMergePaths      map[string]DiffMergeEntry // File paths needing merging // 需要合并的文件路径，包含创建时间用于超时清理
 	DiffMergePathsMu    sync.RWMutex              // Mutex lock to prevent concurrency conflicts // 互斥锁，防止并发冲突
 	OfflineSyncStrategy string                    // Offline device sync strategy // 离线设备同步策略 "newTimeMerge" | "ignoreTimeMerge"
+	failCount           atomic.Int32              // Consecutive broadcast failure counter; connection closed when exceeding threshold // 连续广播失败计数器，超过阈值时主动关闭连接
 }
 
 // initContext initializes the context for the WebSocket connection
@@ -560,7 +562,15 @@ func (c *WebsocketClient) sendBroadcast(payload []byte, isExcludeSelf bool) {
 			continue
 		}
 
-		_ = b.Broadcast(uc.conn)
+		// Track consecutive broadcast failures and close half-broken connections proactively.
+		// 追踪连续广播失败次数，主动关闭半断开的连接（TCP keepalive 未超时但已无法通信）。
+		if err := b.Broadcast(uc.conn); err != nil {
+			if uc.failCount.Add(1) == 4 {
+				uc.conn.WriteClose(1000, []byte("broadcast failed"))
+			}
+		} else {
+			uc.failCount.Store(0)
+		}
 	}
 }
 
@@ -1171,6 +1181,12 @@ func (w *WebsocketServer) BroadcastToUser(uid int64, code *code.Code, action str
 		if uc.conn == nil {
 			continue
 		}
-		_ = b.Broadcast(uc.conn)
+		if err := b.Broadcast(uc.conn); err != nil {
+			if uc.failCount.Add(1) == 4 {
+				uc.conn.WriteClose(1000, []byte("broadcast failed"))
+			}
+		} else {
+			uc.failCount.Store(0)
+		}
 	}
 }


### PR DESCRIPTION

## 问题背景

本 PR 修复了两类影响多端同步可靠性的问题：

1. **lastTime 时间窗口漏同步**：各 SyncHandler 在查询完成*之后*才取当前时间作为 `lastTime` 返回给客户端。查询执行期间其他客户端的写入（`updatedTimestamp` 落在查询结束与取时间之间）会被下次增量同步永久跳过，造成**静默漏同步**。

2. **广播消息缺少 `UpdatedTimestamp`（`lastTime`）字段**：Note / File / Folder 的 delete / rename 广播消息未携带 `UpdatedTimestamp`，导致接收端无法推进本地的 `lastXxxSyncTime`，下次全量同步时这些操作会被**重复下发**。

3. **广播错误被静默丢弃**：`sendBroadcast` 和 `BroadcastToUser` 对 `Broadcast()` 的错误返回值直接丢弃（`_ = b.Broadcast()`），TCP 半断开的连接（keepalive 未超时但已无法通信）无法被主动清理。

---

## 变更内容

### 1. 修复 lastTime 时间窗口漏同步（`ws_note.go` / `ws_file.go` / `ws_folder.go` / `ws_setting.go`）

**根因**：查询后取时间存在窗口期。

**修复方案**：在调用 `ListByLastTime` / `ListByUpdatedTimestamp` **之前**记录 `syncStartTime`，以此作为 `SyncEnd` 消息的 `lastTime` 返回。配合 DAO 层严格大于（`Gt`）的查询条件，下次同步使用 `> syncStartTime` 即可覆盖查询期间的所有写入，且不产生重复下发（客户端 `contentHash` 比对可幂等过滤）。

`ws_setting.go` 额外删除了循环内逐项更新 `lastTime = s.UpdatedTimestamp` 的逻辑及空列表兜底，统一改用 `syncStartTime`。

### 2. 补全广播消息 `UpdatedTimestamp` 字段（`ws_note.go` / `ws_file.go` / `ws_folder.go`）

补全以下所有缺失位置：

| 实体 | 函数 | 操作 | 填充值 |
|------|------|------|--------|
| Note | NoteSync | Delete（记录存在） | `note.UpdatedTimestamp` |
| Note | NoteSync | Delete（记录不存在） | `0` |
| File | FileSync | Delete（记录存在） | `fileSvc.UpdatedTimestamp` |
| File | FileSync | Delete（记录不存在） | `0` |
| Folder | FolderSync | Delete（记录存在） | `folder.UpdatedTimestamp` |
| Folder | FolderSync | Delete（记录不存在） | `0` |
| Folder | FolderSync 消息队列 | Delete | `folder.UpdatedTimestamp` |
| Folder | FolderDelete | Delete | `folder.UpdatedTimestamp` |
| Folder | FolderRename | Rename | `newFolder.UpdatedTimestamp` |

**DTO 变更**：
- `FolderSyncDeleteMessage`：新增 `UpdatedTimestamp int64 \`json:"lastTime"\`` 字段
- `FolderSyncRenameMessage`：新增 `UpdatedTimestamp int64 \`json:"lastTime"\`` 字段
- `FileSyncUploadMessage`：新增 `PathHash string \`json:"pathHash"\`` 字段（供客户端断点续传 checkpoint key 使用）

### 3. 广播错误处理与半断开连接主动清理（`pkg/app/websocket.go`）

- `WebsocketClient` 新增 `failCount atomic.Int32` 字段，追踪连续广播失败次数
- `sendBroadcast` 和 `BroadcastToUser` 两处改为：广播失败时 `failCount` 原子递增，恰好等于 4 时调用 `WriteClose` 主动关闭连接；广播成功时 `Store(0)` 复位
- 使用 `== 4` 而非 `> 3`，保证并发场景下多个 goroutine 同时失败时只触发一次 `WriteClose`

---

## 影响范围

- 所有多端同步场景下的增量同步时间戳推进
- Note / File / Folder 的 delete / rename 实时广播
- TCP 半断开连接的自动清理

## 关联 PR（插件端）

配套插件端 PR 实现了：
- 分块上传断点续传（基于服务端新增的 `pathHash` 字段）
- `folder_operator` 广播接收时实时更新 `lastFolderSyncTime`