### PR TITLE
fix: MCP SSE endpoint 返回相对路径导致部分客户端连接超时

### DIFF
--- a/internal/routers/mcp_router/mcp.go
+++ b/internal/routers/mcp_router/mcp.go
@@ -1,10 +1,12 @@
 package mcp_router
 
 import (
+	"bytes"
 	"context"
-
+	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +15,30 @@ import (
 	pkgapp "github.com/haierkeys/fast-note-sync-service/pkg/app"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
+
+// endpointRewriter is an http.ResponseWriter wrapper that rewrites the
+// SSE endpoint event from a relative path to an absolute URL.
+// This fixes compatibility with MCP clients (e.g., Hermes/Anthropic Python SDK)
+// that cannot resolve relative endpoint paths returned by mark3labs/mcp-go SSEServer.
+type endpointRewriter struct {
+	http.ResponseWriter
+	absoluteBase string // e.g. "http://192.168.1.89:9000"
+	endpointDone bool
+}
+
+func (w *endpointRewriter) Write(data []byte) (int, error) {
+	if !w.endpointDone && bytes.Contains(data, []byte("event: endpoint")) {
+		w.endpointDone = true
+		// Replace relative path with absolute URL in the endpoint event
+		data = []byte(strings.Replace(
+			string(data),
+			"/api/mcp/message?",
+			w.absoluteBase+"/api/mcp/message?",
+			1,
+		))
+	}
+	return w.ResponseWriter.Write(data)
+}
 
 type MCPHandler struct {
 	mcpServer       *mcpserver.MCPServer
@@ -107,8 +133,22 @@ func (h *MCPHandler) HandleSSE(c *gin.Context) {
 		return
 	}
 
-	// Let SSEServer handle the SSE connection
-	h.sseServer.SSEHandler().ServeHTTP(c.Writer, c.Request.WithContext(ctx))
+	// Build absolute URL from the incoming request to fix MCP clients
+	// (e.g., Hermes/Anthropic Python SDK) that cannot resolve relative
+	// endpoint paths returned by mark3labs/mcp-go SSEServer.
+	// See: https://github.com/haierkeys/fast-note-sync-service/issues/258
+	scheme := "http"
+	if c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https" {
+		scheme = "https"
+	}
+	absoluteBase := fmt.Sprintf("%s://%s", scheme, c.Request.Host)
+
+	// Let SSEServer handle the SSE connection, with endpoint URL rewriting
+	rewriter := &endpointRewriter{
+		ResponseWriter: c.Writer,
+		absoluteBase:   absoluteBase,
+	}
+	h.sseServer.SSEHandler().ServeHTTP(rewriter, c.Request.WithContext(ctx))
 }
 
 func (h *MCPHandler) HandleMessage(c *gin.Context) {


### PR DESCRIPTION
## 问题描述

Issue #258: 使用 Hermes (Anthropic Python MCP SDK) 通过 SSE 连接 FNS 服务端时超时。

## 根因分析

`mark3labs/mcp-go` 的 `SSEServer` 在初始化时仅设置了 `WithMessageEndpoint("/api/mcp/message")`，但**未设置 `WithBaseURL()`**。

在 `GetMessageEndpointForClient()` 中，当 `baseURL` 为空时，返回的是**相对路径**：

```
/api/mcp/message?sessionId=xxx
```

Hermes 使用的 Anthropic Python MCP SDK 在解析 SSE endpoint 事件时，对相对路径的处理不够智能——它无法正确将相对路径拼接到原始请求的 scheme+host 上，导致 POST 握手请求发送失败，FNS 收不到握手请求就不下发工具列表，客户端超时 40 秒。

## 修复方案

使用 `http.ResponseWriter` 包装器 `endpointRewriter`，在 SSE 连接建立时拦截 endpoint 事件，将相对路径替换为基于请求 `scheme + host` 的绝对 URL：

```
/api/mcp/message?sessionId=xxx
→ scheme://host/api/mcp/message?sessionId=xxx
```

**优势**：
- **零配置**：自动从请求中推断 scheme 和 host，用户无需配置外部 URL
- **反向代理兼容**：支持 `X-Forwarded-Proto` header
- **最小改动**：仅修改 `HandleSSE()`，不影响 MCP Server 的其他逻辑
- **向后兼容**：返回绝对 URL 对所有 MCP 客户端都有效

## 修改文件

- `internal/routers/mcp_router/mcp.go`: 新增 `endpointRewriter` 包装器，修改 `HandleSSE()`

## 测试

由于环境无 Go 编译器，未进行本地编译验证。逻辑较为简单且安全，仅做字符串替换，建议上游合并前在本地验证。
