### PR TITLE
fix: 重命名/移动时复用记录未重置 Rename 标志导致笔记统计不准确

### DIFF
--- a/internal/service/file_service.go
+++ b/internal/service/file_service.go
@@ -819,6 +819,7 @@ func (s *fileService) Rename(ctx context.Context, uid int64, params *dto.FileRen
 		if existFile != nil {
 			// 复用已删除的记录
 			existFile.Action = domain.FileActionCreate
+			existFile.Rename = 0 // Reset rename flag to ensure correct file count statistics
 			existFile.Path = newPath
 			existFile.PathHash = newPathHash
 			newPathDir := ""

--- a/internal/service/note_service.go
+++ b/internal/service/note_service.go
@@ -634,6 +634,7 @@ func (s *noteService) Rename(ctx context.Context, uid int64, params *dto.NoteRen
 		if existNote != nil {
 			// Reuse deleted record // 复用已删除的记录
 			existNote.Action = domain.NoteActionCreate
+			existNote.Rename = 0 // Reset rename flag to ensure correct note count statistics
 			existNote.Path = newPath
 			existNote.PathHash = newPathHash
 			newPathDir := ""


### PR DESCRIPTION
## 问题描述

在 Obsidian 客户端移动子目录或重命名文件夹后，后台笔记库的笔记数据统计不准确（400多篇笔记只统计出十几篇），实际笔记并未丢失。关联 issue: #265

## 根因分析

`CountSizeSum` 在统计笔记/文件数量时，使用 `Rename.Eq(0)` 过滤条件，排除 `Rename=1` 的记录（即正在执行重命名操作的中间状态记录）。

当重命名目标路径存在已删除的记录（`existNote`/`existFile`）时，代码会复用该记录：

1. 设置 `Action = create`（正确）
2. **但未重置 `Rename = 0`**（Bug）
3. 保留了该记录之前的 `Rename` 值

**触发条件**：目标路径的已删除记录之前是通过重命名操作产生的（`Rename=1`），或者经历了多次重命名。

**影响**：
- `note_service.go`：`Rename()` 函数的 `existNote` 复用路径
- `file_service.go`：`Rename()` 函数的 `existFile` 复用路径（同样问题）

注意：正常的新建记录路径（`existNote == nil`）不受影响，因为 Go 结构体字面量默认 `Rename=0`。

## 修复内容

在两个文件的复用路径中，显式设置 `Rename = 0`：

- `internal/service/note_service.go`：第 637 行，`existNote.Rename = 0`
- `internal/service/file_service.go`：第 822 行，`existFile.Rename = 0`

## 测试

- 修复后，复用路径产生的记录 `Rename=0`，可被 `CountSizeSum` 正确统计
- 不影响正常的重命名流程（旧记录 `Rename=1` 标记仍然正确用于区分中间状态）
