### PR TITLE
fix(auth): return session errors for stale stateful tokens

### DIFF
--- a/internal/middleware/user_auth_token_test.go
+++ b/internal/middleware/user_auth_token_test.go
@@ -1,0 +1,168 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/haierkeys/fast-note-sync-service/internal/domain"
+	"github.com/haierkeys/fast-note-sync-service/internal/dto"
+	"github.com/haierkeys/fast-note-sync-service/pkg/app"
+	"github.com/haierkeys/fast-note-sync-service/pkg/code"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeMiddlewareTokenService struct {
+	activeToken *domain.AuthToken
+	activeErr   error
+}
+
+func (s *fakeMiddlewareTokenService) Create(ctx context.Context, uid int64, params *dto.TokenIssueRequest) (*dto.TokenCreateResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) CreateForLogin(ctx context.Context, uid int64, clientType, ip, userAgent string) (*domain.AuthToken, string, error) {
+	return nil, "", errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) ListByUser(ctx context.Context, uid int64) ([]*dto.TokenResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) Update(ctx context.Context, uid int64, tokenID int64, params *dto.TokenUpdateRequest) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) Revoke(ctx context.Context, uid int64, tokenID int64) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) Rotate(ctx context.Context, uid int64, tokenID int64) (*dto.TokenCreateResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) GetActiveToken(ctx context.Context, uid int64, tokenID int64) (*domain.AuthToken, error) {
+	return s.activeToken, s.activeErr
+}
+
+func (s *fakeMiddlewareTokenService) RecordAccessLog(ctx context.Context, log *domain.AuthTokenLog) error {
+	return nil
+}
+
+func (s *fakeMiddlewareTokenService) ListLogs(ctx context.Context, uid, tokenID int64, page, pageSize int) ([]*dto.TokenLogResponse, int64, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) UpdateLastUsedAt(ctx context.Context, tokenID int64) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeMiddlewareTokenService) SetSyncHandler(handler func(uid int64, tokenID int64, scope string, kick bool)) {
+}
+
+func newMiddlewareJWT(t *testing.T, secretKey, nonce string) string {
+	t.Helper()
+	tokenManager := app.NewTokenManager(app.TokenConfig{
+		SecretKey: secretKey,
+		Expiry:    time.Hour,
+	})
+	token, err := tokenManager.Generate(1, "", "", 2, nonce)
+	require.NoError(t, err)
+	return token
+}
+
+func runUserAuthMiddleware(t *testing.T, tokenService *fakeMiddlewareTokenService, token string) app.Res {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(UserAuthTokenWithConfig("test-secret", tokenService))
+	router.GET("/api/note/list", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/note/list?path=test.md", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("x-client", "ObsidianPlugin")
+	req.Header.Set("User-Agent", "Obsidian")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var res app.Res
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &res))
+	return res
+}
+
+func TestUserAuthTokenWithConfig_AllowsValidManualTokenScope(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddleware(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:rest,ws c:ObsidianPlugin f:note_rw,file_rw,config_rw",
+		IssueType:   2,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token)
+
+	assert.Equal(t, code.Success.Code(), res.Code)
+}
+
+func TestUserAuthTokenWithConfig_PropagatesInvalidStatefulToken(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "stale-nonce")
+	res := runUserAuthMiddleware(t, &fakeMiddlewareTokenService{
+		activeErr: code.ErrorInvalidUserAuthToken.WithDetails("Token has been revoked or no longer exists"),
+	}, token)
+
+	assert.Equal(t, code.ErrorInvalidUserAuthToken.Code(), res.Code)
+	assert.Contains(t, res.Details, "revoked")
+}
+
+func TestUserAuthTokenWithConfig_PropagatesExpiredToken(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "expired-nonce")
+	res := runUserAuthMiddleware(t, &fakeMiddlewareTokenService{
+		activeErr: code.ErrorTokenExpired,
+	}, token)
+
+	assert.Equal(t, code.ErrorTokenExpired.Code(), res.Code)
+}
+
+func TestUserAuthTokenWithConfig_RejectsNonceMismatch(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "old-nonce")
+	res := runUserAuthMiddleware(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "new-nonce",
+		Status:      1,
+		Scope:       "p:rest,ws c:ObsidianPlugin f:note_rw,file_rw,config_rw",
+		IssueType:   2,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token)
+
+	assert.Equal(t, code.ErrorInvalidUserAuthToken.Code(), res.Code)
+	assert.Contains(t, res.Details, "rotated")
+}
+
+func TestUserAuthTokenWithConfig_RejectsScopeRestrictedToken(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddleware(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:ws c:ObsidianPlugin f:note_rw",
+		IssueType:   2,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token)
+
+	assert.Equal(t, code.ErrorAuthTokenScopeRestricted.Code(), res.Code)
+	assert.Contains(t, res.Details, "Permission denied")
+}

--- a/internal/service/token_service.go
+++ b/internal/service/token_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/haierkeys/fast-note-sync-service/pkg/timex"
 	"github.com/haierkeys/fast-note-sync-service/pkg/util"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 )
 
 // TokenService defines the token management service interface
@@ -46,7 +48,7 @@ type tokenService struct {
 	logRepo      domain.AuthTokenLogRepository
 	tokenManager app.TokenManager
 	logger       *zap.Logger
-	lastLogMap   sync.Map                                     // TokenID -> time.Time (for 30s rate limiting)
+	lastLogMap   sync.Map                                                // TokenID -> time.Time (for 30s rate limiting)
 	SyncHandler  func(uid int64, tokenID int64, scope string, kick bool) // Hook for syncing to other modules (like WS)
 }
 
@@ -379,10 +381,16 @@ func (s *tokenService) ListLogs(ctx context.Context, uid, tokenID int64, page, p
 func (s *tokenService) GetActiveToken(ctx context.Context, uid int64, tokenID int64) (*domain.AuthToken, error) {
 	token, err := s.tokenRepo.GetByID(ctx, tokenID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, code.ErrorInvalidUserAuthToken.WithDetails("Token has been revoked or no longer exists")
+		}
 		return nil, code.ErrorDBQuery.WithDetails(err.Error())
 	}
-	if token.UID != uid || token.Status != 1 {
-		return nil, code.ErrorInvalidAuthToken
+	if token.UID != uid {
+		return nil, code.ErrorInvalidUserAuthToken.WithDetails("Token does not belong to the authenticated user")
+	}
+	if token.Status != 1 {
+		return nil, code.ErrorInvalidUserAuthToken.WithDetails("Token has been revoked or no longer exists")
 	}
 	if time.Now().After(token.ExpiredAt) {
 		return nil, code.ErrorTokenExpired

--- a/internal/service/token_service_test.go
+++ b/internal/service/token_service_test.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/haierkeys/fast-note-sync-service/internal/domain"
+	"github.com/haierkeys/fast-note-sync-service/pkg/app"
+	"github.com/haierkeys/fast-note-sync-service/pkg/code"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type stubAuthTokenRepository struct {
+	getByIDToken *domain.AuthToken
+	getByIDErr   error
+}
+
+func (r *stubAuthTokenRepository) Create(ctx context.Context, token *domain.AuthToken) (*domain.AuthToken, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) GetByID(ctx context.Context, id int64) (*domain.AuthToken, error) {
+	return r.getByIDToken, r.getByIDErr
+}
+
+func (r *stubAuthTokenRepository) GetByTokenString(ctx context.Context, tokenString string) (*domain.AuthToken, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) ListByUID(ctx context.Context, uid int64) ([]*domain.AuthToken, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) Update(ctx context.Context, token *domain.AuthToken) error {
+	return errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) UpdateScope(ctx context.Context, id int64, scope string) error {
+	return errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) UpdateLastUsedAt(ctx context.Context, id int64) error {
+	return errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) Revoke(ctx context.Context, id int64) error {
+	return errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) RevokeAllByUID(ctx context.Context, uid int64) error {
+	return errors.New("not implemented")
+}
+
+func (r *stubAuthTokenRepository) UpdateTokenString(ctx context.Context, id int64, tokenString string) error {
+	return errors.New("not implemented")
+}
+
+func tokenErrorCode(t *testing.T, err error) int {
+	t.Helper()
+	require.Error(t, err)
+	appErr, ok := err.(*code.Code)
+	require.True(t, ok, "expected *code.Code, got %T", err)
+	return appErr.Code()
+}
+
+func TestTokenService_GetActiveToken_RecordNotFoundIsSessionError(t *testing.T) {
+	svc := NewTokenService(
+		&stubAuthTokenRepository{getByIDErr: gorm.ErrRecordNotFound},
+		nil,
+		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
+		nil,
+	)
+
+	token, err := svc.GetActiveToken(context.Background(), 1, 2)
+
+	assert.Nil(t, token)
+	assert.Equal(t, code.ErrorInvalidUserAuthToken.Code(), tokenErrorCode(t, err))
+}
+
+func TestTokenService_GetActiveToken_RevokedIsSessionError(t *testing.T) {
+	svc := NewTokenService(
+		&stubAuthTokenRepository{getByIDToken: &domain.AuthToken{
+			ID:        2,
+			UID:       1,
+			Status:    0,
+			ExpiredAt: time.Now().Add(time.Hour),
+		}},
+		nil,
+		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
+		nil,
+	)
+
+	token, err := svc.GetActiveToken(context.Background(), 1, 2)
+
+	assert.Nil(t, token)
+	assert.Equal(t, code.ErrorInvalidUserAuthToken.Code(), tokenErrorCode(t, err))
+}
+
+func TestTokenService_GetActiveToken_WrongUserIsSessionError(t *testing.T) {
+	svc := NewTokenService(
+		&stubAuthTokenRepository{getByIDToken: &domain.AuthToken{
+			ID:        2,
+			UID:       99,
+			Status:    1,
+			ExpiredAt: time.Now().Add(time.Hour),
+		}},
+		nil,
+		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
+		nil,
+	)
+
+	token, err := svc.GetActiveToken(context.Background(), 1, 2)
+
+	assert.Nil(t, token)
+	assert.Equal(t, code.ErrorInvalidUserAuthToken.Code(), tokenErrorCode(t, err))
+}
+
+func TestTokenService_GetActiveToken_ExpiredRemainsExpired(t *testing.T) {
+	svc := NewTokenService(
+		&stubAuthTokenRepository{getByIDToken: &domain.AuthToken{
+			ID:        2,
+			UID:       1,
+			Status:    1,
+			ExpiredAt: time.Now().Add(-time.Hour),
+		}},
+		nil,
+		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
+		nil,
+	)
+
+	token, err := svc.GetActiveToken(context.Background(), 1, 2)
+
+	assert.Nil(t, token)
+	assert.Equal(t, code.ErrorTokenExpired.Code(), tokenErrorCode(t, err))
+}
+
+func TestTokenService_GetActiveToken_DBFailureRemainsDBError(t *testing.T) {
+	svc := NewTokenService(
+		&stubAuthTokenRepository{getByIDErr: errors.New("database offline")},
+		nil,
+		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
+		nil,
+	)
+
+	token, err := svc.GetActiveToken(context.Background(), 1, 2)
+
+	assert.Nil(t, token)
+	assert.Equal(t, code.ErrorDBQuery.Code(), tokenErrorCode(t, err))
+}
+
+func TestTokenService_GetActiveToken_Valid(t *testing.T) {
+	want := &domain.AuthToken{
+		ID:        2,
+		UID:       1,
+		Status:    1,
+		ExpiredAt: time.Now().Add(time.Hour),
+	}
+	svc := NewTokenService(
+		&stubAuthTokenRepository{getByIDToken: want},
+		nil,
+		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
+		nil,
+	)
+
+	got, err := svc.GetActiveToken(context.Background(), 1, 2)
+
+	assert.NoError(t, err)
+	assert.Same(t, want, got)
+}

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/haierkeys/fast-note-sync-service/internal/domain"
@@ -21,7 +22,7 @@ import (
 // mockTokenManager 是用于 UserService 测试的最小 TokenManager stub。
 type mockTokenManager struct{}
 
-func (m *mockTokenManager) Generate(uid int64, nickname, ip string) (string, error) {
+func (m *mockTokenManager) Generate(uid int64, nickname, ip string, tokenID int64, nonce string) (string, error) {
 	return "test-token", nil
 }
 func (m *mockTokenManager) Parse(token string) (*pkgapp.UserEntity, error) {
@@ -36,10 +37,55 @@ func (m *mockTokenManager) ShareParse(token string) (*pkgapp.ShareEntity, error)
 func (m *mockTokenManager) Validate(token string) error { return nil }
 func (m *mockTokenManager) GetSecretKey() string        { return "test-key" }
 
+type mockUserTokenService struct{}
+
+func (m *mockUserTokenService) Create(ctx context.Context, uid int64, params *dto.TokenIssueRequest) (*dto.TokenCreateResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) CreateForLogin(ctx context.Context, uid int64, clientType, ip, userAgent string) (*domain.AuthToken, string, error) {
+	return &domain.AuthToken{ID: 1, UID: uid, Status: 1}, "test-token", nil
+}
+
+func (m *mockUserTokenService) ListByUser(ctx context.Context, uid int64) ([]*dto.TokenResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) Update(ctx context.Context, uid int64, tokenID int64, params *dto.TokenUpdateRequest) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) Revoke(ctx context.Context, uid int64, tokenID int64) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) Rotate(ctx context.Context, uid int64, tokenID int64) (*dto.TokenCreateResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) GetActiveToken(ctx context.Context, uid int64, tokenID int64) (*domain.AuthToken, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) RecordAccessLog(ctx context.Context, log *domain.AuthTokenLog) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) ListLogs(ctx context.Context, uid, tokenID int64, page, pageSize int) ([]*dto.TokenLogResponse, int64, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) UpdateLastUsedAt(ctx context.Context, tokenID int64) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockUserTokenService) SetSyncHandler(handler func(uid int64, tokenID int64, scope string, kick bool)) {
+}
+
 // newUserSvc creates a userService with mocked dependencies for testing.
 // newUserSvc 创建带 mock 依赖的 userService 用于测试。
 func newUserSvc(repo domain.UserRepository, registerEnabled bool) UserService {
-	return NewUserService(repo, &mockTokenManager{}, zap.NewNop(), &ServiceConfig{
+	return NewUserService(repo, &mockTokenManager{}, &mockUserTokenService{}, zap.NewNop(), &ServiceConfig{
 		User: UserServiceConfig{RegisterIsEnable: registerEnabled, AdminUID: 1},
 	})
 }
@@ -70,7 +116,7 @@ func TestUserService_Register_Success(t *testing.T) {
 		Return(created, nil)
 
 	svc := newUserSvc(mockRepo, true)
-	result, err := svc.Register(context.Background(), params)
+	result, err := svc.Register(context.Background(), params, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -89,7 +135,7 @@ func TestUserService_Register_Disabled(t *testing.T) {
 		Username:        "user1",
 		Password:        "pass",
 		ConfirmPassword: "pass",
-	})
+	}, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.ErrorIs(t, err, code.ErrorUserRegisterIsDisable)
 	mockRepo.AssertExpectations(t) // no repo calls expected // 期望没有 Repository 调用
@@ -106,7 +152,7 @@ func TestUserService_Register_PasswordMismatch(t *testing.T) {
 		Username:        "validuser",
 		Password:        "pass1",
 		ConfirmPassword: "pass2",
-	})
+	}, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.ErrorIs(t, err, code.ErrorUserPasswordNotMatch)
 	mockRepo.AssertExpectations(t)
@@ -126,7 +172,7 @@ func TestUserService_Register_EmailExists(t *testing.T) {
 		Username:        "newuser",
 		Password:        "password123",
 		ConfirmPassword: "password123",
-	})
+	}, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.ErrorIs(t, err, code.ErrorUserEmailAlreadyExists)
 	mockRepo.AssertExpectations(t)
@@ -150,7 +196,7 @@ func TestUserService_Register_UsernameExists(t *testing.T) {
 		Username:        "takenuser",
 		Password:        "password123",
 		ConfirmPassword: "password123",
-	})
+	}, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.ErrorIs(t, err, code.ErrorUserAlreadyExists)
 	mockRepo.AssertExpectations(t)
@@ -182,7 +228,7 @@ func TestUserService_Login_ByEmail_Success(t *testing.T) {
 	result, err := svc.Login(context.Background(), &dto.UserLoginRequest{
 		Credentials: "test@example.com",
 		Password:    "password",
-	}, "127.0.0.1")
+	}, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -207,7 +253,7 @@ func TestUserService_Login_WrongPassword(t *testing.T) {
 	_, err := svc.Login(context.Background(), &dto.UserLoginRequest{
 		Credentials: "test@example.com",
 		Password:    "wrong-password",
-	}, "127.0.0.1")
+	}, "127.0.0.1", "WebGui", "test-agent")
 
 	assert.ErrorIs(t, err, code.ErrorUserLoginPasswordFailed)
 	mockRepo.AssertExpectations(t)
@@ -281,7 +327,7 @@ func TestUserService_ChangePassword_Success(t *testing.T) {
 func TestUserService_IsRegisterEnabled(t *testing.T) {
 	t.Run("ConfigDisabled", func(t *testing.T) {
 		mockRepo := new(domainmocks.MockUserRepository)
-		svc := NewUserService(mockRepo, &mockTokenManager{}, zap.NewNop(), &ServiceConfig{
+		svc := NewUserService(mockRepo, &mockTokenManager{}, &mockUserTokenService{}, zap.NewNop(), &ServiceConfig{
 			User: UserServiceConfig{RegisterIsEnable: false, AdminUID: 0},
 		})
 		assert.False(t, svc.IsRegisterEnabled(context.Background()))
@@ -289,7 +335,7 @@ func TestUserService_IsRegisterEnabled(t *testing.T) {
 
 	t.Run("AdminUIDSet_Enabled", func(t *testing.T) {
 		mockRepo := new(domainmocks.MockUserRepository)
-		svc := NewUserService(mockRepo, &mockTokenManager{}, zap.NewNop(), &ServiceConfig{
+		svc := NewUserService(mockRepo, &mockTokenManager{}, &mockUserTokenService{}, zap.NewNop(), &ServiceConfig{
 			User: UserServiceConfig{RegisterIsEnable: true, AdminUID: 1},
 		})
 		assert.True(t, svc.IsRegisterEnabled(context.Background()))
@@ -298,7 +344,7 @@ func TestUserService_IsRegisterEnabled(t *testing.T) {
 	t.Run("AdminUIDZero_NoUsers", func(t *testing.T) {
 		mockRepo := new(domainmocks.MockUserRepository)
 		mockRepo.On("GetAllUIDs", mock.Anything).Return([]int64{}, nil)
-		svc := NewUserService(mockRepo, &mockTokenManager{}, zap.NewNop(), &ServiceConfig{
+		svc := NewUserService(mockRepo, &mockTokenManager{}, &mockUserTokenService{}, zap.NewNop(), &ServiceConfig{
 			User: UserServiceConfig{RegisterIsEnable: true, AdminUID: 0},
 		})
 		assert.True(t, svc.IsRegisterEnabled(context.Background()))
@@ -308,7 +354,7 @@ func TestUserService_IsRegisterEnabled(t *testing.T) {
 	t.Run("AdminUIDZero_WithUsers", func(t *testing.T) {
 		mockRepo := new(domainmocks.MockUserRepository)
 		mockRepo.On("GetAllUIDs", mock.Anything).Return([]int64{1}, nil)
-		svc := NewUserService(mockRepo, &mockTokenManager{}, zap.NewNop(), &ServiceConfig{
+		svc := NewUserService(mockRepo, &mockTokenManager{}, &mockUserTokenService{}, zap.NewNop(), &ServiceConfig{
 			User: UserServiceConfig{RegisterIsEnable: true, AdminUID: 0},
 		})
 		assert.False(t, svc.IsRegisterEnabled(context.Background()))

--- a/internal/service/vault_service_test.go
+++ b/internal/service/vault_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/haierkeys/fast-note-sync-service/pkg/code"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -20,6 +21,10 @@ import (
 // newVaultMockRepo 为每个测试返回新的 MockVaultRepository。
 func newVaultMockRepo() *domainmocks.MockVaultRepository {
 	return new(domainmocks.MockVaultRepository)
+}
+
+func newVaultSvc(repo *domainmocks.MockVaultRepository) VaultService {
+	return NewVaultService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, zap.NewNop())
 }
 
 // newVault creates a domain.Vault test fixture.
@@ -54,7 +59,7 @@ func TestVaultService_Create_Success(t *testing.T) {
 	mockRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.Vault"), int64(1)).
 		Return(created, nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	result, err := svc.Create(context.Background(), 1, "MyVault")
 
 	assert.NoError(t, err)
@@ -71,7 +76,7 @@ func TestVaultService_Create_AlreadyExists(t *testing.T) {
 	mockRepo.On("GetByName", mock.Anything, "MyVault", int64(1)).
 		Return(existing, nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	_, err := svc.Create(context.Background(), 1, "MyVault")
 
 	assert.ErrorIs(t, err, code.ErrorVaultExist)
@@ -89,7 +94,7 @@ func TestVaultService_Get_Success(t *testing.T) {
 	mockRepo.On("GetByID", mock.Anything, int64(5), int64(1)).
 		Return(v, nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	result, err := svc.Get(context.Background(), 1, 5)
 
 	assert.NoError(t, err)
@@ -105,7 +110,7 @@ func TestVaultService_Get_NotFound(t *testing.T) {
 	mockRepo.On("GetByID", mock.Anything, int64(99), int64(1)).
 		Return(nil, gorm.ErrRecordNotFound)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	_, err := svc.Get(context.Background(), 1, 99)
 
 	assert.ErrorIs(t, err, code.ErrorVaultNotFound)
@@ -126,7 +131,7 @@ func TestVaultService_List_Success(t *testing.T) {
 	mockRepo.On("List", mock.Anything, int64(1)).
 		Return(fixturesToDomain(vaults), nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	results, err := svc.List(context.Background(), 1)
 
 	assert.NoError(t, err)
@@ -142,15 +147,62 @@ func TestVaultService_List_Success(t *testing.T) {
 // TestVaultService_Delete_Success 验证正常删除 Vault 的逻辑。
 func TestVaultService_Delete_Success(t *testing.T) {
 	mockRepo := newVaultMockRepo()
+	noteRepo := new(domainmocks.MockNoteRepository)
+	fileRepo := new(domainmocks.MockFileRepository)
+	folderRepo := new(domainmocks.MockFolderRepository)
+	logRepo := new(domainmocks.MockSyncLogRepository)
+	historyRepo := new(domainmocks.MockNoteHistoryRepository)
+	linkRepo := new(domainmocks.MockNoteLinkRepository)
+	settingRepo := new(domainmocks.MockSettingRepository)
+	ftsRepo := new(domainmocks.MockNoteFTSRepository)
+	shareRepo := new(domainmocks.MockUserShareRepository)
+	gitRepo := new(domainmocks.MockGitSyncRepository)
+	backupRepo := new(domainmocks.MockBackupRepository)
 
+	noteRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	fileRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	folderRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	logRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	historyRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	linkRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	ftsRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	shareRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	gitRepo.On("DisableByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	backupRepo.On("DisableByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
+	settingRepo.On("DeleteByVaultID", mock.Anything, int64(3), int64(1)).Return(nil)
 	mockRepo.On("Delete", mock.Anything, int64(3), int64(1)).
 		Return(nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := NewVaultService(
+		mockRepo,
+		noteRepo,
+		fileRepo,
+		folderRepo,
+		logRepo,
+		historyRepo,
+		linkRepo,
+		settingRepo,
+		ftsRepo,
+		shareRepo,
+		gitRepo,
+		backupRepo,
+		zap.NewNop(),
+	)
 	err := svc.Delete(context.Background(), 1, 3)
 
 	assert.NoError(t, err)
 	mockRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+	fileRepo.AssertExpectations(t)
+	folderRepo.AssertExpectations(t)
+	logRepo.AssertExpectations(t)
+	historyRepo.AssertExpectations(t)
+	linkRepo.AssertExpectations(t)
+	settingRepo.AssertExpectations(t)
+	ftsRepo.AssertExpectations(t)
+	shareRepo.AssertExpectations(t)
+	gitRepo.AssertExpectations(t)
+	backupRepo.AssertExpectations(t)
 }
 
 // --- Update ---
@@ -172,7 +224,7 @@ func TestVaultService_Update_Success(t *testing.T) {
 	mockRepo.On("GetByID", mock.Anything, int64(7), int64(1)).
 		Return(updated, nil).Once()
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	result, err := svc.Update(context.Background(), 1, 7, "NewName")
 
 	assert.NoError(t, err)
@@ -188,7 +240,7 @@ func TestVaultService_Update_NotFound(t *testing.T) {
 	mockRepo.On("GetByID", mock.Anything, int64(99), int64(1)).
 		Return(nil, gorm.ErrRecordNotFound)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	_, err := svc.Update(context.Background(), 1, 99, "NewName")
 
 	assert.ErrorIs(t, err, code.ErrorVaultNotFound)
@@ -206,7 +258,7 @@ func TestVaultService_GetOrCreate_ExistingVault(t *testing.T) {
 	mockRepo.On("GetByName", mock.Anything, "MyVault", int64(1)).
 		Return(existing, nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	result, err := svc.GetOrCreate(context.Background(), 1, "MyVault")
 
 	assert.NoError(t, err)
@@ -226,7 +278,7 @@ func TestVaultService_GetOrCreate_NewVault(t *testing.T) {
 	mockRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.Vault"), int64(1)).
 		Return(created, nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	result, err := svc.GetOrCreate(context.Background(), 1, "NewVault")
 
 	assert.NoError(t, err)
@@ -244,7 +296,7 @@ func TestVaultService_UpdateNoteStats(t *testing.T) {
 	mockRepo.On("UpdateNoteCountSize", mock.Anything, int64(1024), int64(5), int64(1), int64(1)).
 		Return(nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	err := svc.UpdateNoteStats(context.Background(), 1024, 5, 1, 1)
 
 	assert.NoError(t, err)
@@ -259,7 +311,7 @@ func TestVaultService_UpdateFileStats(t *testing.T) {
 	mockRepo.On("UpdateFileCountSize", mock.Anything, int64(2048), int64(3), int64(1), int64(1)).
 		Return(nil)
 
-	svc := NewVaultService(mockRepo)
+	svc := newVaultSvc(mockRepo)
 	err := svc.UpdateFileStats(context.Background(), 2048, 3, 1, 1)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- map missing `auth_token` rows to `ErrorInvalidUserAuthToken` instead of `ErrorDBQuery`
- treat wrong-user and inactive token rows as invalid user auth token states
- keep expired tokens distinct as `ErrorTokenExpired`
- preserve `ErrorDBQuery` for real repository/database failures
- add focused service and middleware regression tests for missing, revoked, expired, nonce mismatch, and scope restricted cases

## Why
A stale or revoked stateful token row is an authentication/session problem, not a database outage. Surfacing it as `Code=301 record not found` makes Obsidian startup authorization failures hard to diagnose and inconsistent between REST and WebSocket auth paths.

## Tests
- `go test ./internal/middleware ./internal/service`

Note: `go test ./...` still has unrelated existing failures in `scratch`, `internal/routers/api_router/handler_share_test.go`, and a few platform/flaky package tests.