### PR TITLE
feat: add issue templates (bug report & feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,157 @@
+name: Bug Report / 问题报告
+description: File a bug report / 提交问题反馈
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report / 问题报告
+        Thanks for taking the time to fill out this bug report! 
+        Please use a clear and descriptive title that summarizes your issue, so developers can address it effectively.
+        感谢你花时间填写这个问题报告！请起一个能够清晰描述您的问题的标题，便于开发者解决您的问题。
+        > [!important]
+        > Please search existing [Issues](https://github.com/haierkeys/fast-note-sync-service/issues) to see if an issue already exists for the bug you encountered. 
+        > 请搜索现有 [Issue](https://github.com/haierkeys/fast-note-sync-service/issues)，以确认您遇到的 Bug 是否已有对应的 Issue。
+        >
+        > If you are unsure how to describe your problem clearly and effectively, we recommend reading [_How to Ask Questions the Smart Way_](http://www.catb.org/~esr/faqs/smart-questions.html). 
+        > 如果您不知道如何有效、精准地表述，我们建议您先阅读[《提问的智慧》](https://github.com/ryanhanwu/How-To-Ask-Questions-The-Smart-Way/blob/main/README-zh_CN.md)。
+  
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened? / 发生了什么？
+      description:
+      placeholder: |
+        Describe the bug here / 在此描述问题...
+        You can drag and drop files, such as images and videos, here. / 你可以拖拽图片、视频等文件到此处
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior / 预期行为
+      description:
+      placeholder: What should have happened? / 本应该发生什么？
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce / 复现步骤
+      description:
+      placeholder: |
+        1. Open Obsidian, go to '...' / 1. 打开 Obsidian，进入“...”
+        2. Click on '....' / 2. 点击“....”
+        3. Scroll to '....' / 3. 滚动到“....”
+        4. See error / 4. 看到错误
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Environment / 环境信息
+
+  - type: input
+    id: obsidian-version
+    attributes:
+      label: Obsidian Version / Obsidian 版本
+      description: You can find this in Settings → About / 在 设置 → 关于 中可以找到
+      placeholder: e.g. 1.12.7 / 例如 1.12.7
+    validations:
+      required: false
+
+  - type: dropdown
+    id: client-os
+    attributes:
+      label: Client Operating System (where Obsidian runs) / 插件端操作系统（Obsidian 运行环境）
+      description: Select all that apply / 可多选
+      multiple: true
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - iOS
+        - Android
+        - Other / 其他 (Please specify in "Additional Context" below / 请在下方“补充说明”中填写)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: server-os
+    attributes:
+      label: Server Operating System / 服务端操作系统
+      description: Select all that apply / 可多选
+      multiple: true
+      options:
+        - Linux (Ubuntu/Debian/CentOS/...)
+        - Windows
+        - macOS
+        - Other / 其他 (Please specify in "Additional Context" below / 请在下方“补充说明”中填写)
+    validations:
+      required: false
+      
+
+  - type: textarea
+    id: other-plugins
+    attributes:
+      label: Other Active Plugins / 其他启用的插件
+      description: |
+        List any other active plugins that might be relevant. This helps identify conflicts.
+        / 列出其他可能相关的启用插件，这有助于排查插件冲突。
+      placeholder:
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Debug Information / 调试信息
+
+  - type: textarea
+    id: debug-info
+    attributes:
+      label: Plugin Debug Info / 插件 Debug 信息
+      description: |
+        In Plugin Settings → General, click the "Copy Debug Info" button at the bottom, and paste it here.
+        / 在 插件设置 → 通用，点击底部“复制 Debug 信息”，粘贴在这里。
+      render: json
+      placeholder:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / 日志
+      description:
+      render: shell
+      placeholder:
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context / 补充说明
+      description:
+      placeholder:
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: revision
+    attributes:
+      label: "Final Step / 最后一步"
+      description: "Review your answer / 回顾您的回答"
+      options:
+        - label: |
+            I believe the above description is detailed enough for the developer to reproduce the issue. If my issue is not filled out as requested, it may be **closed without explanation**.
+            我认为上述的描述已经足以详细，以允许开发人员能复现该问题。如果我的 Issue 没有按照上述的要求填写，可能会被 **无条件关闭**。
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature Request / 功能请求
+description: Suggest an idea for this project / 为该项目提出一个新想法
+title: "[Feature Request]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your idea! Please use a clear and descriptive title that summarizes the feature, so developers can understand your request.
+        感谢您贡献您的想法。请起一个能够清晰概括此功能的标题，便于开发者了解您的想法。
+
+        ### Checklist / 检查清单
+
+        Before submitting a request, please confirm the following:
+        在提出建议之前，请先确认以下所有事项：
+
+        1. I have updated to the [latest version](https://github.com/haierkeys/fast-note-sync-service/releases/latest) and checked the [latest commits](https://github.com/haierkeys/fast-note-sync-service/commits/master/) to confirm that my desired feature has not been implemented.  
+           我已更新到[最新版](https://github.com/haierkeys/fast-note-sync-service/releases/latest)，并看过[最新提交](https://github.com/haierkeys/fast-note-sync-service/commits/master/)，确认我想要的功能还没有实现。
+
+        2. I have searched [Issues](https://github.com/haierkeys/fast-note-sync-service/issues) and confirmed that a similar request has **not been submitted**.  
+           我已在 [Issues](https://github.com/haierkeys/fast-note-sync-service/issues) 中检索，确认这一类似的建议 **未被提交过**。
+
+        3. I understand that due to the developer's limited time and energy, my feature request may take a long time to be implemented.  
+           我已知晓由于插件开发者时间精力有限，我提交的功能请求可能需要比较久的时间才能实现。
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "Confirmation Checklist / 确认检查清单"
+      description: "Please confirm before creating this issue / 在创建此 Issue 之前，请先确认"
+      options:
+        - label: |
+            I have read and confirmed the checklist above. / 我已阅读以上清单并确认。
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request / 功能请求
+
+        Describe the feature you want. You can attach screenshots, screen recordings, stack traces, logs, etc., to help the developer understand.
+        描述您想要的功能。您可以附上截图、录屏、堆栈跟踪、日志等材料，便于插件开发者进行开发。
+
+  - type: textarea
+    id: back
+    attributes:
+      label: "Background & Motivation / 背景与动机"
+      description: "Why should this feature be added? (Optional) / 添加此功能的理由。（可选）"
+    validations:
+      required: false
+
+  - type: textarea
+    id: req
+    attributes:
+      label: "Desired Feature / 想要实现或优化的功能"
+      description: |
+        Describe in detail the feature you want. The more specific, the higher the likelihood it will be implemented. You can also attach images or other attachments to help the developer better understand your intent.
+        详细地描述一下你想要的功能，描述的越具体，有人制作的可能性越高；也可以提供图片等附件，以使开发者更好理解您的意图。
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: revision
+    attributes:
+      label: "Final Step / 最后一步"
+      description: "Review your answer / 回顾您的回答"
+      options:
+        - label: |
+            I believe the above description is detailed enough for the developer to understand the feature I want. If my issue is not filled out as requested, it may be **closed without explanation**.
+            我认为上述的描述已经足以详细，以便插件开发人员理解您想要的功能。如果我的 Issue 没有按照上述的要求填写，可能会被 **无条件关闭**。
+          required: true


### PR DESCRIPTION
## Summary / 概述

Add issue templates for better issue management.
添加议题模板，以便更好地管理议题。

## Changes / 变更内容

- Add `bug_report.yml` - Bug report template with bilingual support
  添加 `bug_report.yml` - 双语的 Bug 报告模板

- Add `feature_request.yml` - Feature request template with bilingual support
  添加 `feature_request.yml` - 双语的功能请求模板

## Notes / 备注

You can modify the templates as needed. If you find the bilingual (English/Chinese) layout too crowded, feel free to separate them into different sections or files.
你可以根据需要自行修改模板。如果你觉得议题模板中的中英文放在一起很拥挤，可以将它们分开。

You can also make some simple modifications and then place these templates in the `https://github.com/haierkeys/obsidian-fast-note-sync` project at the same time.
你也可以把这些模板做些简单修改，然后同时放到 `https://github.com/haierkeys/obsidian-fast-note-sync` 项目中。