### PR TITLE
fix: 修复 default true 布尔配置 false 被覆盖

### DIFF
--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigPreservesExplicitFalseAndEmptyDefaults(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(configPath, []byte(`
+app:
+  ws-parallel-enabled: false
+  ws-check-utf8-enabled: false
+  ws-compression-enabled: false
+security:
+  webgui-login-token-expiry:
+  webgui-login-token-bind-ip: false
+tracer:
+  enabled: false
+storage:
+  local-fs:
+    httpfs-is-enable: false
+  aliyun-oss:
+    is-enable: false
+  aws-s3:
+    is-enable:
+database:
+  auto-migrate: false
+user-database:
+  auto-migrate: false
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, _, err := LoadConfig(configPath)
+	require.NoError(t, err)
+
+	require.False(t, *cfg.App.WebSocketParallelEnabled)
+	require.False(t, *cfg.App.WebSocketCheckUtf8Enabled)
+	require.False(t, *cfg.App.WebSocketCompressionEnabled)
+	require.False(t, *cfg.Security.WebGUILoginTokenBindIP)
+	require.False(t, *cfg.Tracer.Enabled)
+	require.False(t, *cfg.Storage.LocalFS.HttpfsIsEnable)
+	require.False(t, *cfg.Storage.AliyunOSS.IsEnabled)
+	require.False(t, *cfg.Database.AutoMigrate)
+	require.False(t, *cfg.UserDatabase.AutoMigrate)
+
+	require.Equal(t, "7d", cfg.Security.WebGUILoginTokenExpiry)
+	require.True(t, *cfg.Storage.AwsS3.IsEnabled)
+	require.True(t, *cfg.Storage.MinIO.IsEnabled)
+}

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -35,7 +35,7 @@ func initServices(cfg *AppConfig, infra *Infra, repos *Repositories, logger *zap
 		},
 		Token: service.TokenServiceConfig{
 			WebGUILoginTokenExpiry: cfg.Security.WebGUILoginTokenExpiry,
-			WebGUILoginTokenBindIP: cfg.Security.WebGUILoginTokenBindIP,
+			WebGUILoginTokenBindIP: *cfg.Security.WebGUILoginTokenBindIP,
 		},
 		App: service.AppServiceConfig{
 			SoftDeleteRetentionTime: cfg.App.SoftDeleteRetentionTime,

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -61,10 +61,10 @@ type AppSettings struct {
 	// WebSocket 配置
 	WebSocketReadMaxPayloadSize   string `yaml:"ws-read-max-payload-size" default:"128MB"`
 	WebSocketWriteMaxPayloadSize  string `yaml:"ws-write-max-payload-size" default:"128MB"`
-	WebSocketParallelEnabled      bool   `yaml:"ws-parallel-enabled" default:"true"`
+	WebSocketParallelEnabled      *bool  `yaml:"ws-parallel-enabled" default:"true"`
 	WebSocketParallelGolimit      int    `yaml:"ws-parallel-golimit" default:"3"`
-	WebSocketCheckUtf8Enabled     bool   `yaml:"ws-check-utf8-enabled" default:"true"`
-	WebSocketCompressionEnabled   bool   `yaml:"ws-compression-enabled" default:"true"`
+	WebSocketCheckUtf8Enabled     *bool  `yaml:"ws-check-utf8-enabled" default:"true"`
+	WebSocketCompressionEnabled   *bool  `yaml:"ws-compression-enabled" default:"true"`
 	WebSocketCompressionLevel     int    `yaml:"ws-compression-level" default:"1"`
 	WebSocketCompressionThreshold int    `yaml:"ws-compression-threshold" default:"512"`
 	// PullSource data pull source: auto | github | cnb

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -13,7 +13,7 @@ type DatabaseConfig struct {
 	SSLMode             string `yaml:"ssl-mode"`                                   // SSL mode (postgres only) // SSL 模式 (仅限 postgres)
 	TablePrefix         string `yaml:"table-prefix"`                               // database table prefix // 数据库表前缀
 	Schema              string `yaml:"schema"`                                     // database schema (postgres only) // 数据库 Schema (仅限 postgres)
-	AutoMigrate         bool   `yaml:"auto-migrate" default:"true"`                // whether to enable automatic migration // 是否启用自动迁移
+	AutoMigrate         *bool  `yaml:"auto-migrate" default:"true"`                // whether to enable automatic migration // 是否启用自动迁移
 	Charset             string `yaml:"charset"`                                    // database charset // 数据库字符集
 	ParseTime           bool   `yaml:"parse-time"`                                 // whether to parse time // 是否解析时间
 	MaxIdleConns        int    `yaml:"max-idle-conns" default:"10"`                // maximum number of idle connections // 最大闲置连接数，默认 10

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -15,5 +15,5 @@ type SecurityConfig struct {
 	WebGUILoginTokenExpiry string `yaml:"webgui-login-token-expiry" default:"7d"`
 	// WebGUILoginTokenBindIP whether to bind the client IP when issuing WebGUI login tokens
 	// WebGUILoginTokenBindIP 签发 WebGUI 登录 Token 时是否绑定客户端 IP
-	WebGUILoginTokenBindIP bool `yaml:"webgui-login-token-bind-ip" default:"true"`
+	WebGUILoginTokenBindIP *bool `yaml:"webgui-login-token-bind-ip" default:"true"`
 }

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -15,12 +15,12 @@ type StorageConfig struct {
 // StorageLocalFSConfig 本地文件系统存储配置
 type StorageLocalFSConfig struct {
 	IsEnabled      bool   `yaml:"is-enable" default:"false"`       // Default false as per user requirement, but logically might need enabled
-	HttpfsIsEnable bool   `yaml:"httpfs-is-enable" default:"true"` // Default true
+	HttpfsIsEnable *bool  `yaml:"httpfs-is-enable" default:"true"` // Default true
 	SavePath       string `yaml:"save-path" default:"storage/uploads"`
 }
 
 // StorageBaseConfig Base configuration for cloud storages
 // StorageBaseConfig 云存储基础配置
 type StorageBaseConfig struct {
-	IsEnabled bool `yaml:"is-enable" default:"true"` // Default enabled
+	IsEnabled *bool `yaml:"is-enable" default:"true"` // Default enabled
 }

--- a/internal/config/tracer.go
+++ b/internal/config/tracer.go
@@ -5,7 +5,7 @@ package config
 type TracerConfig struct {
 	// Enabled whether tracing is enabled
 	// Enabled 是否启用追踪
-	Enabled bool `yaml:"enabled" default:"true"`
+	Enabled *bool `yaml:"enabled" default:"true"`
 	// Header tracing ID request header name, default X-Trace-ID
 	// Header 追踪 ID 请求头名称，默认 X-Trace-ID
 	Header string `yaml:"header" default:"X-Trace-ID"`

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -646,7 +646,7 @@ func (d *Dao) AutoMigrate(uid int64, modelKey string) error {
 
 	// 2. Verify the AutoMigrate flag in the configuration
 	// 2. 校验配置中的 AutoMigrate 标志
-	if !cfg.AutoMigrate {
+	if cfg.AutoMigrate != nil && !*cfg.AutoMigrate {
 		return nil
 	}
 

--- a/internal/routers/api_router/handler_admin_control.go
+++ b/internal/routers/api_router/handler_admin_control.go
@@ -445,6 +445,7 @@ func (h *AdminControlHandler) ValidateUserDatabaseConfig(c *gin.Context) {
 	if params.Type == "sqlite" {
 		enableQueue = true
 	}
+	autoMigrate := true
 	dbCfg := config.DatabaseConfig{
 		Type:                params.Type,
 		Path:                params.Path,
@@ -455,7 +456,7 @@ func (h *AdminControlHandler) ValidateUserDatabaseConfig(c *gin.Context) {
 		Name:                params.Name,
 		SSLMode:             params.SSLMode,
 		Schema:              params.Schema,
-		AutoMigrate:         true,
+		AutoMigrate:         &autoMigrate,
 		MaxIdleConns:        params.MaxIdleConns,
 		MaxOpenConns:        params.MaxOpenConns,
 		ConnMaxLifetime:     params.ConnMaxLifetime,

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -59,13 +59,13 @@ func NewRouter(frontendFiles embed.FS, appContainer *app.App, uni *ut.UniversalT
 	var wss = pkgapp.NewWebsocketServer(pkgapp.WSConfig{
 		GWSOption: gws.ServerOption{
 			ResponseHeader:   responseHeader,
-			CheckUtf8Enabled: cfg.App.WebSocketCheckUtf8Enabled,
-			ParallelEnabled:  cfg.App.WebSocketParallelEnabled, // Enable parallel message processing from config
+			CheckUtf8Enabled: *cfg.App.WebSocketCheckUtf8Enabled,
+			ParallelEnabled:  *cfg.App.WebSocketParallelEnabled, // Enable parallel message processing from config
 			// 从配置开启并行消息处理
 			Recovery: gws.Recovery, // Enable exception recovery
 			// 开启异常恢复
 			PermessageDeflate: gws.PermessageDeflate{
-				Enabled:               cfg.App.WebSocketCompressionEnabled,
+				Enabled:               *cfg.App.WebSocketCompressionEnabled,
 				Level:                 cfg.App.WebSocketCompressionLevel,
 				Threshold:             cfg.App.WebSocketCompressionThreshold,
 				ServerContextTakeover: true,

--- a/internal/routers/router_api.go
+++ b/internal/routers/router_api.go
@@ -20,7 +20,7 @@ func registerAPIRoutes(r *gin.Engine, appContainer *app.App, wss *pkgapp.Websock
 	{
 		api.Use(middleware.AppInfoWithConfig(app.Name, appContainer.Version().Version))
 		api.Use(gin.Logger())
-		api.Use(middleware.TraceMiddlewareWithConfig(cfg.Tracer.Enabled, cfg.Tracer.Header)) // Trace ID middleware
+		api.Use(middleware.TraceMiddlewareWithConfig(*cfg.Tracer.Enabled, cfg.Tracer.Header)) // Trace ID middleware
 		// Trace ID 中间件
 		api.Use(middleware.RateLimiter(methodLimiters))
 

--- a/internal/routers/router_static.go
+++ b/internal/routers/router_static.go
@@ -34,7 +34,7 @@ func registerStaticFiles(r *gin.Engine, frontendFiles embed.FS, appContainer *ap
 	r.Group("/static", cacheMiddleware, middleware.StaticCompressMiddleware(frontendFiles)).StaticFS("/", http.FS(frontendStatic))
 	r.Group("/user_static", cacheMiddleware).Static("/", userStaticPath)
 
-	if cfg.Storage.LocalFS.HttpfsIsEnable && cfg.Storage.LocalFS.IsEnabled {
+	if *cfg.Storage.LocalFS.HttpfsIsEnable && cfg.Storage.LocalFS.IsEnabled {
 		r.StaticFS(cfg.Storage.LocalFS.SavePath, http.Dir(cfg.Storage.LocalFS.SavePath))
 		r.OPTIONS(cfg.Storage.LocalFS.SavePath+"/*filepath", func(c *gin.Context) {
 			c.Status(http.StatusNoContent)

--- a/internal/service/storage_service.go
+++ b/internal/service/storage_service.go
@@ -196,19 +196,19 @@ func (s *storageService) GetEnabledTypes() ([]string, error) {
 	if s.config.LocalFS.IsEnabled {
 		types = append(types, string(storage.LOCAL))
 	}
-	if s.config.AliyunOSS.IsEnabled {
+	if *s.config.AliyunOSS.IsEnabled {
 		types = append(types, string(storage.OSS))
 	}
-	if s.config.AwsS3.IsEnabled {
+	if *s.config.AwsS3.IsEnabled {
 		types = append(types, string(storage.S3))
 	}
-	if s.config.CloudflareR2.IsEnabled {
+	if *s.config.CloudflareR2.IsEnabled {
 		types = append(types, string(storage.R2))
 	}
-	if s.config.MinIO.IsEnabled {
+	if *s.config.MinIO.IsEnabled {
 		types = append(types, string(storage.MinIO))
 	}
-	if s.config.WebDAV.IsEnabled {
+	if *s.config.WebDAV.IsEnabled {
 		types = append(types, string(storage.WebDAV))
 	}
 	return types, nil
@@ -219,15 +219,15 @@ func (s *storageService) isStorageTypeEnabled(t string) bool {
 	case storage.LOCAL:
 		return s.config.LocalFS.IsEnabled
 	case storage.OSS:
-		return s.config.AliyunOSS.IsEnabled
+		return *s.config.AliyunOSS.IsEnabled
 	case storage.S3:
-		return s.config.AwsS3.IsEnabled
+		return *s.config.AwsS3.IsEnabled
 	case storage.R2:
-		return s.config.CloudflareR2.IsEnabled
+		return *s.config.CloudflareR2.IsEnabled
 	case storage.MinIO:
-		return s.config.MinIO.IsEnabled
+		return *s.config.MinIO.IsEnabled
 	case storage.WebDAV:
-		return s.config.WebDAV.IsEnabled
+		return *s.config.WebDAV.IsEnabled
 	default:
 		return false
 	}

--- a/internal/service/token_service_test.go
+++ b/internal/service/token_service_test.go
@@ -73,6 +73,7 @@ func TestTokenService_GetActiveToken_RecordNotFoundIsSessionError(t *testing.T) 
 		nil,
 		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
 		nil,
+		TokenServiceConfig{},
 	)
 
 	token, err := svc.GetActiveToken(context.Background(), 1, 2)
@@ -92,6 +93,7 @@ func TestTokenService_GetActiveToken_RevokedIsSessionError(t *testing.T) {
 		nil,
 		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
 		nil,
+		TokenServiceConfig{},
 	)
 
 	token, err := svc.GetActiveToken(context.Background(), 1, 2)
@@ -111,6 +113,7 @@ func TestTokenService_GetActiveToken_WrongUserIsSessionError(t *testing.T) {
 		nil,
 		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
 		nil,
+		TokenServiceConfig{},
 	)
 
 	token, err := svc.GetActiveToken(context.Background(), 1, 2)
@@ -130,6 +133,7 @@ func TestTokenService_GetActiveToken_ExpiredRemainsExpired(t *testing.T) {
 		nil,
 		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
 		nil,
+		TokenServiceConfig{},
 	)
 
 	token, err := svc.GetActiveToken(context.Background(), 1, 2)
@@ -144,6 +148,7 @@ func TestTokenService_GetActiveToken_DBFailureRemainsDBError(t *testing.T) {
 		nil,
 		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
 		nil,
+		TokenServiceConfig{},
 	)
 
 	token, err := svc.GetActiveToken(context.Background(), 1, 2)
@@ -164,6 +169,7 @@ func TestTokenService_GetActiveToken_Valid(t *testing.T) {
 		nil,
 		app.NewTokenManager(app.TokenConfig{SecretKey: "test-secret"}),
 		nil,
+		TokenServiceConfig{},
 	)
 
 	got, err := svc.GetActiveToken(context.Background(), 1, 2)


### PR DESCRIPTION
## 问题描述

Issue #301 中提到关闭 WebGUI 登录 Token IP 绑定后仍然提示 IP 限制。配置文件中即使设置：

```yaml
security:
  webgui-login-token-bind-ip: false
```

服务启动后该值仍会被加载为默认值 `true`，导致新签发的 WebGUI 登录 Token 继续绑定客户端 IP。

## 根因分析

`LoadConfig` 在 YAML 解析前后各执行了一次 `defaults.Set(c)`。第二次执行用于填充 YAML 中显式留空的配置项，但 `defaults.Set` 按 Go 零值判断是否需要填默认值。

普通 `bool` 的零值是 `false`，因此显式配置的 `false` 会被误认为空值，并被 `default:"true"` 覆盖回 `true`。

## 修复内容

将需要支持显式关闭、且默认值为 `true` 的布尔配置字段改为 `*bool`，用 nil 和非 nil 区分“未配置/空配置”和“显式配置 false”：

- WebSocket 相关开关
- `security.webgui-login-token-bind-ip`
- `tracer.enabled`
- 本地文件 HTTP 访问开关
- 云存储 `is-enable` 开关
- 数据库 `auto-migrate` 开关

同时更新相关使用处进行解引用，并为手动构造的数据库配置补充指针值。

## 测试

- `go test ./internal/app ./internal/service ./internal/middleware ./internal/routers ./internal/dao`

## 关联 Issue

Refs #301