### PR TITLE
fix: 修复 Web 端图片资源请求 Client mismatch

### DIFF
--- a/internal/middleware/user_auth_token.go
+++ b/internal/middleware/user_auth_token.go
@@ -87,6 +87,9 @@ func UserAuthTokenWithConfig(secretKey string, tokenService service.TokenService
 		if reqClientType == "" {
 			reqClientType = c.Query("client")
 		}
+		if reqClientType == "" && dbToken.IssueType == 1 && isHeaderlessLoginTokenResourceRead(c) {
+			reqClientType = dbToken.ClientType
+		}
 
 		// Only enforce strict ClientType matching for login tokens (IssueType == 1).
 		// Manual tokens (IssueType == 2) use ClientType as a Remark/Title, and client restriction is handled via Scope.
@@ -206,6 +209,11 @@ func UserAuthTokenWithConfig(secretKey string, tokenService service.TokenService
 		c.Set("vaults", dbToken.Vaults)
 		c.Next()
 	}
+}
+
+func isHeaderlessLoginTokenResourceRead(c *gin.Context) bool {
+	return c.Request.URL.Path == "/api/file" &&
+		(c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead)
 }
 
 // UserAuthToken user Token authentication middleware (no secret key, always fails)

--- a/internal/middleware/user_auth_token_test.go
+++ b/internal/middleware/user_auth_token_test.go
@@ -82,6 +82,13 @@ func newMiddlewareJWT(t *testing.T, secretKey, nonce string) string {
 }
 
 func runUserAuthMiddleware(t *testing.T, tokenService *fakeMiddlewareTokenService, token string) app.Res {
+	return runUserAuthMiddlewareWithRequest(t, tokenService, token, http.MethodGet, "/api/note/list?path=test.md", func(req *http.Request) {
+		req.Header.Set("x-client", "ObsidianPlugin")
+		req.Header.Set("User-Agent", "Obsidian")
+	})
+}
+
+func runUserAuthMiddlewareWithRequest(t *testing.T, tokenService *fakeMiddlewareTokenService, token string, method string, target string, configure func(*http.Request)) app.Res {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -90,11 +97,18 @@ func runUserAuthMiddleware(t *testing.T, tokenService *fakeMiddlewareTokenServic
 	router.GET("/api/note/list", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
 	})
+	router.GET("/api/file", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
+	})
+	router.POST("/api/file", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
+	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/note/list?path=test.md", nil)
+	req := httptest.NewRequest(method, target, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-client", "ObsidianPlugin")
-	req.Header.Set("User-Agent", "Obsidian")
+	if configure != nil {
+		configure(req)
+	}
 	recorder := httptest.NewRecorder()
 
 	router.ServeHTTP(recorder, req)
@@ -169,4 +183,56 @@ func TestUserAuthTokenWithConfig_RejectsScopeRestrictedToken(t *testing.T) {
 
 	assert.Equal(t, code.ErrorAuthTokenScopeRestricted.Code(), res.Code)
 	assert.Contains(t, res.Details, "Permission denied")
+}
+
+func TestUserAuthTokenWithConfig_AllowsLoginTokenWithoutClientHeader(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddlewareWithRequest(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:rest c:WebGui f:*",
+		ClientType:  "WebGui",
+		IssueType:   1,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token, http.MethodGet, "/api/file?vault=main&path=image.png", func(req *http.Request) {
+		req.Header.Set("User-Agent", "Mozilla/5.0")
+	})
+
+	assert.Equal(t, code.Success.Code(), res.Code)
+}
+
+func TestUserAuthTokenWithConfig_RejectsHeaderlessLoginTokenWrite(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddlewareWithRequest(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:rest c:WebGui f:*",
+		ClientType:  "WebGui",
+		IssueType:   1,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token, http.MethodPost, "/api/file?vault=main&path=image.png", func(req *http.Request) {
+		req.Header.Set("User-Agent", "Mozilla/5.0")
+	})
+
+	assert.Equal(t, code.ErrorAuthTokenClientRestricted.Code(), res.Code)
+}
+
+func TestUserAuthTokenWithConfig_RejectsManualTokenWithoutClientHeader(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddlewareWithRequest(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:rest c:WebGui f:file_r",
+		ClientType:  "WebGui",
+		IssueType:   2,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token, http.MethodGet, "/api/file?vault=main&path=image.png", nil)
+
+	assert.Equal(t, code.ErrorAuthTokenScopeRestricted.Code(), res.Code)
 }


### PR DESCRIPTION
## 问题描述

Issue #287 中 Web 端浏览笔记时，图片和下载资源请求返回：

```json
{"code":314,"status":false,"message":"安全令牌客户端 (Client) 访问受限","details":"Client mismatch"}
```

## 根因分析

WebGUI 登录签发的登录 Token 会绑定 `ClientType=WebGui`，普通 API 请求可以通过 `x-client` header 传递客户端类型。

但 Markdown 预览中的图片、视频、音频以及浏览器下载等原生资源请求无法携带自定义 header，只能携带 URL query 中的 token，因此请求进入鉴权中间件时 `reqClientType` 为空。

中间件随后对登录 Token 执行严格 ClientType 匹配，使用空 client 与 `WebGui` 比较，导致返回 `Client mismatch`。

## 修复内容

当请求未显式提供 client，且当前 token 是登录签发 token (`IssueType == 1`) 时，使用数据库中该 token 的 `ClientType` 作为当前请求 client。

这样可以兼容 WebGUI 的原生资源请求，同时不放宽手动 token 的客户端限制：手动 token 仍然需要显式提供 client，并继续通过 Scope 校验控制权限。

## 测试

- `go test ./internal/middleware`
- `go test ./internal/middleware ./internal/routers ./internal/routers/api_router`

## 关联 Issue

Refs #287