### PR TITLE
fix(note): decode percent-encoded paths when resolving markdown image refs

### DIFF
--- a/internal/service/share_service.go
+++ b/internal/service/share_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -1027,6 +1028,19 @@ func buildSharePathCandidates(notePath string, rawRef string) []string {
 	ref := strings.TrimSpace(strings.ReplaceAll(rawRef, "\\", "/"))
 	if ref == "" || !isLocalSharePath(ref) {
 		return nil
+	}
+
+	// Standard markdown image links require characters such as spaces or
+	// non-ASCII to be percent-encoded (e.g. "图片/foo%201.jpg"), but the
+	// canonical path stored in the file table is the literal Obsidian path
+	// (e.g. "图片/foo 1.jpg"). Decode percent-encoding here so the DB lookup
+	// matches regardless of which link form the note used.
+	// 标准 Markdown 图片链接中的空格、非 ASCII 字符等需要百分号编码（如
+	// "图片/foo%201.jpg"），但文件表里存的是 Obsidian 原始字面路径
+	// （如 "图片/foo 1.jpg"）。这里解码百分号编码，让数据库查找在任何
+	// 链接形式下都能命中。
+	if decoded, err := url.PathUnescape(ref); err == nil && decoded != "" {
+		ref = decoded
 	}
 
 	candidates := make([]string, 0, 2)


### PR DESCRIPTION
## 问题 / Problem
在 WebGUI 中，使用标准 Markdown 语法 `![alt](path)` 的图片，当 path 中含有转义成“%“的字符时无法显示，会出现图片破损（alt有值时）或变成分割线（alt为空时）。

如果 path 的中文未转义成“%“的字符，那么就可以正常显示（至于什么时候中文会被转义，什么时候中文不会被转义，我不知道）。
如果 path 中含有空格但又未转义成`%20`，就直接显示图片链接的文本，不显示图片（这种情况 obsidian 本身也不支持，但是其他 Markdown 编辑器，如 Typroa 是支持的）。

例如，#96 #221 中反馈的问题：

<img width="1164" height="560" alt="2026-05-25_140810" src="https://github.com/user-attachments/assets/84d2f3e8-51bd-4c4b-9a70-451c05b8d73e" />

## 根因 / Root Cause

后端在 `internal/service/share_service.go` 的 `buildSharePathCandidates` 中根据笔记里提取到的引用串 `rawRef` 拼出待查询路径，再用它在 `file` 表中按 `path` 查找。

- Obsidian 在标准 Markdown `![alt](url)` 里写入路径时，会按 URL 规则把空格、中文等转义为 `%20` 等百分号编码。
- 但 `file` 表里存的是 Obsidian 原始字面路径（含字面空格和中文）。
- Wiki 与 HTML `<img src=…>` 标签形式不做百分号编码，所以查找命中。
- 标准 Markdown 形式带 `%20` 时，候选路径与 DB 不一致，查询不到 → `FileLinks` 没有这条映射 → 前端拿不到可用 URL → 图片渲染失败。

## 修复 / Fix

在 `buildSharePathCandidates` 里对 `rawRef` 做一次 `url.PathUnescape`（单点修复，同时覆盖普通笔记流和 share 流）：

- 修复后用解码后的 ref 拼候选路径，能命中 DB 里的字面路径。
- 上游传给前端 / 重写器的 map key 仍保持原始（编码后的）ref，因此前端按 markdown 原文查 `FileLinks` 不受影响。
- `url.PathUnescape` 失败时回退到原始 ref，零回归。

## 测试 / Tests
使用修复后的本地 Winodws 服务端，验证转义成"%"的图片路径在笔记、分享笔记可正常显示图片
<img width="1279" height="1366" alt="2026-05-25_141642" src="https://github.com/user-attachments/assets/81d41f72-f93e-4568-9818-7bc39da4b7ee" />

## 关联 issue
#96 #221