### PR TITLE
 feat(note): extract & rewrite html <video>/<audio>/<source> tags in share flow

### DIFF
--- a/internal/service/share_service.go
+++ b/internal/service/share_service.go
@@ -1012,6 +1012,23 @@ targetStart:
 	return raw[start:end], start, end
 }
 
+// detectMediaKindByExt returns "image", "video", "audio", or "" based on the
+// file extension of p. Extensions are matched case-insensitively.
+// detectMediaKindByExt 根据 p 的扩展名返回 "image"、"video"、"audio" 或 ""，
+// 大小写不敏感。
+func detectMediaKindByExt(p string) string {
+	ext := strings.ToLower(filepath.Ext(p))
+	switch ext {
+	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp":
+		return "image"
+	case ".mp4", ".webm", ".mov", ".mkv", ".avi", ".ogv":
+		return "video"
+	case ".mp3", ".wav", ".m4a", ".flac", ".aac", ".ogg":
+		return "audio"
+	}
+	return ""
+}
+
 func rewriteMarkdownImageLinks(content string, fileRefs map[string]*domain.File, shareToken string, password string) string {
 	return markdownImageRegex.ReplaceAllStringFunc(content, func(match string) string {
 		submatches := markdownImageRegex.FindStringSubmatch(match)
@@ -1029,13 +1046,37 @@ func rewriteMarkdownImageLinks(content string, fileRefs map[string]*domain.File,
 			return match
 		}
 
-		replacementTarget := buildSharedFileAPIURL(file.ID, shareToken, password)
+		apiURL := buildSharedFileAPIURL(file.ID, shareToken, password)
+		alt := submatches[1]
+
+		// Dispatch by file extension so that markdown image syntax pointing
+		// at a video or audio file (e.g. `![alt](clip.mp4)`) is rendered as
+		// a proper <video>/<audio> HTML element in the share view, instead
+		// of a broken <img>. This mirrors the wiki-style ![[]] dispatch
+		// already done in the attachment rewriter above, and is the server-
+		// side counterpart of the webgui's rewriteMarkdownImageLinks media
+		// dispatch.
+		// 按文件扩展名分发：让 Markdown 图片语法指向视频/音频的引用
+		// （如 `![alt](clip.mp4)`）在分享视图中渲染为 <video>/<audio> HTML，
+		// 而不是坏掉的 <img>。与上面 wiki 风格 ![[]] 附件重写器的分发逻辑
+		// 一致，也是 webgui 端 rewriteMarkdownImageLinks 媒体分发的服务端
+		// 对应物。
+		switch detectMediaKindByExt(file.Path) {
+		case "video":
+			return `<video src="` + apiURL + `" controls style="max-width:100%"></video>`
+		case "audio":
+			return `<audio src="` + apiURL + `" controls></audio>`
+		}
+
+		// Image (default) — preserve the original markdown image form, only
+		// substituting the URL.
+		replacementTarget := apiURL
 		rawTarget := submatches[2][start:end]
 		if strings.HasPrefix(rawTarget, "<") && strings.HasSuffix(rawTarget, ">") {
 			replacementTarget = "<" + replacementTarget + ">"
 		}
 
-		return "![" + submatches[1] + "](" + submatches[2][:start] + replacementTarget + submatches[2][end:] + ")"
+		return "![" + alt + "](" + submatches[2][:start] + replacementTarget + submatches[2][end:] + ")"
 	})
 }
 

--- a/internal/service/share_service.go
+++ b/internal/service/share_service.go
@@ -38,7 +38,34 @@ var (
 	// htmlImageRegex regular expression for html images
 	// htmlImageRegex html 图片正则表达式
 	htmlImageRegex = regexp.MustCompile(`(?i)<img\b([^>]*?)\bsrc\s*=\s*(['"])(.*?)['"]([^>]*)>`)
+	// htmlVideoRegex regular expression for html video tags whose src is on
+	// the tag itself (the alternative form using nested <source> children is
+	// captured separately by htmlSourceRegex below).
+	// htmlVideoRegex 匹配 src 写在标签自身上的 HTML <video>（嵌套 <source>
+	// 形式由下方 htmlSourceRegex 单独捕获）。
+	htmlVideoRegex = regexp.MustCompile(`(?i)<video\b([^>]*?)\bsrc\s*=\s*(['"])(.*?)['"]([^>]*)>`)
+	// htmlAudioRegex regular expression for html audio tags whose src is on
+	// the tag itself.
+	// htmlAudioRegex 匹配 src 写在标签自身上的 HTML <audio>。
+	htmlAudioRegex = regexp.MustCompile(`(?i)<audio\b([^>]*?)\bsrc\s*=\s*(['"])(.*?)['"]([^>]*)>`)
+	// htmlSourceRegex regular expression for the <source> tag, typically
+	// nested inside <video>/<audio>; commonly written self-closing.
+	// htmlSourceRegex 匹配 <source> 标签，通常嵌套在 <video>/<audio> 内，且
+	// 多以自闭合形式书写。
+	htmlSourceRegex = regexp.MustCompile(`(?i)<source\b([^>]*?)\bsrc\s*=\s*(['"])(.*?)['"]([^>]*)>`)
 )
+
+// htmlMediaRegexes lists the HTML media tags whose `src` attribute should be
+// extracted as a shared-note file reference and rewritten to a share API URL
+// during the share render pipeline.
+//
+// htmlMediaRegexes 列出在分享渲染流程中需要将 src 属性当作分享笔记文件引用
+// 提取并改写为分享 API URL 的 HTML 媒体标签。
+var htmlMediaRegexes = []*regexp.Regexp{
+	htmlVideoRegex,
+	htmlAudioRegex,
+	htmlSourceRegex,
+}
 
 // ShareService defines the share business service interface
 // ShareService 定义分享业务服务接口
@@ -790,6 +817,21 @@ func (s *shareService) GetSharedNote(ctx context.Context, shareToken string, not
 	})
 	newContent = rewriteMarkdownImageLinks(newContent, fileRefs, shareToken, password)
 	newContent = rewriteHTMLImageSources(newContent, fileRefs, shareToken, password)
+	// Rewrite any inline HTML <video>/<audio>/<source> the user wrote
+	// directly in their note. Each tag has the same `src` capture shape as
+	// <img>, so reuse rewriteHTMLMediaSources for all three. This pairs with
+	// the htmlMediaRegexes loop in extractSharedNoteFileRefs which gates
+	// share authorization; without the rewrite, src would still point at the
+	// raw vault path and the share viewer's <video>/<audio> player could not
+	// fetch the file (it has no auth context for the vault file route).
+	// 把用户直接写在笔记里的内联 HTML <video>/<audio>/<source> 一并改写。
+	// 三者 src 的捕获形态与 <img> 完全一致，因此复用 rewriteHTMLMediaSources。
+	// 该步骤与 extractSharedNoteFileRefs 中的 htmlMediaRegexes 循环成对使用：
+	// 提取负责把 src 路径放进分享授权资源，重写则把 src 替换为分享 API URL，
+	// 否则分享视图里的播放器拿到的是原始 vault 路径，没有授权也就无法加载。
+	newContent = rewriteHTMLMediaSources(newContent, htmlVideoRegex, "video", fileRefs, shareToken, password)
+	newContent = rewriteHTMLMediaSources(newContent, htmlAudioRegex, "audio", fileRefs, shareToken, password)
+	newContent = rewriteHTMLMediaSources(newContent, htmlSourceRegex, "source", fileRefs, shareToken, password)
 	noteDTO.Content = newContent
 
 	return noteDTO, nil
@@ -888,6 +930,36 @@ func extractSharedNoteFileRefs(content string) []string {
 		refs = append(refs, ref)
 	}
 
+	// HTML media tags (<video src=...>, <audio src=...>, <source src=...>)
+	// share the same `src` capture position as <img>, so a single loop over
+	// htmlMediaRegexes is enough to extract their refs into the file map.
+	// Without this, shared notes containing raw HTML like
+	//   <video src="assets/clip.mp4" controls></video>
+	// would never have "assets/clip.mp4" added to fileLinks, leaving the
+	// downstream rewriter unable to swap the path for an authorized share
+	// API URL and the embedded player unable to load the file.
+	// HTML 媒体标签（<video src=...>、<audio src=...>、<source src=...>）的
+	// `src` 捕获位与 <img> 一致，因此遍历 htmlMediaRegexes 即可。如果不在此
+	// 处提取，分享笔记中如下这类原生 HTML 的 src 永远不会进入 fileLinks，
+	// 后续的重写器也就无法把路径替换为带授权信息的分享 API URL，前端的播放
+	// 器自然就加载不到文件。
+	for _, re := range htmlMediaRegexes {
+		for _, match := range re.FindAllStringSubmatch(content, -1) {
+			if len(match) < 4 {
+				continue
+			}
+			ref := strings.TrimSpace(match[3])
+			if ref == "" || !isLocalSharePath(ref) {
+				continue
+			}
+			if _, ok := seen[ref]; ok {
+				continue
+			}
+			seen[ref] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+
 	return refs
 }
 
@@ -980,6 +1052,42 @@ func rewriteHTMLImageSources(content string, fileRefs map[string]*domain.File, s
 		}
 
 		return "<img" + submatches[1] + "src=" + submatches[2] + buildSharedFileAPIURL(file.ID, shareToken, password) + submatches[2] + submatches[4] + ">"
+	})
+}
+
+// rewriteHTMLMediaSources rewrites the `src` attribute on every HTML media
+// tag matched by `re` (e.g. <video>, <audio>, <source>) to the per-file
+// share API URL when the original src resolves through fileRefs. The match
+// shape is identical to htmlImageRegex (groups: beforeSrc, quote, rawSrc,
+// afterSrc), so the replacement reuses the same template, including
+// preservation of any trailing `/` from a self-closing form like
+// `<source ... />` (which falls inside `afterSrc`).
+//
+// This is the pipeline counterpart of extractSharedNoteFileRefs's media
+// loop: extraction populates fileRefs, rewriting then swaps paths for
+// authorized share URLs so the embedded player can fetch the file.
+//
+// rewriteHTMLMediaSources 将匹配到的 HTML 媒体标签（<video>/<audio>/<source>）
+// 的 src 属性改写为按文件 ID 生成的分享 API URL；正则的捕获位与
+// htmlImageRegex 完全一致，所以替换模板可以复用，包括把 `<source ... />`
+// 这种自闭合形式的尾部 `/`（落在 afterSrc 中）保留下来。
+//
+// 该函数与 extractSharedNoteFileRefs 中的媒体提取循环成对使用：先在提取阶段
+// 把 src 加入 fileRefs，然后在此处把 src 替换为带授权的分享 URL，前端播放器
+// 才能拉到对应文件。
+func rewriteHTMLMediaSources(content string, re *regexp.Regexp, tagName string, fileRefs map[string]*domain.File, shareToken string, password string) string {
+	return re.ReplaceAllStringFunc(content, func(match string) string {
+		submatches := re.FindStringSubmatch(match)
+		if len(submatches) < 5 {
+			return match
+		}
+
+		file := fileRefs[strings.TrimSpace(submatches[3])]
+		if file == nil {
+			return match
+		}
+
+		return "<" + tagName + submatches[1] + "src=" + submatches[2] + buildSharedFileAPIURL(file.ID, shareToken, password) + submatches[2] + submatches[4] + ">"
 	})
 }
 


### PR DESCRIPTION
## 概述
在 https://github.com/haierkeys/fast-note-sync-service/pull/314 的基础上扩展了视频和音频，在 WebGUI 的笔记和分享笔记能正常显示播放使用标准 markdown 超链接和HTML `<video >`,`<audio>`的视频、音频。

**配套前端 PR**
需配合 `kqint/fast-note-sync-webgui` 的 [PR](https://github.com/haierkeys/fast-note-sync-webgui/pull/15)  一起使用，该 PR 在 sanitize schema 中放行了 video/audio/source 标签，并在客户端实现了同样的重写逻辑，两者共同确保内联 HTML 媒体标签在分享视图中真正可用。

**还需要将前端产物重新构建打包至服务端。**

---

**Why**

当笔记中包含内联 HTML 媒体——例如 `<video src="assets/clip.mp4" controls width="500"></video>`、`<audio src="assets/music.mp3" controls></audio>` 或包含 `<source>` 子标签的嵌套形式时，分享视图当前会静默失效。

根因有二：

1. `extractSharedNoteFileRefs` 只检查了 `![[ ]]`、`![]( )` 和 `<img>`。媒体标签中的 `src` 路径从未进入已解析的文件映射表，因此分享授权层会将其视为范围外资源，文件 API 将拒绝通过分享 token 提供服务。
2. 下游的重写器仅知道 `<img>` 的 `src`，即使文件已被授权，播放器拿到的依然是原始 vault 路径（如 `assets/clip.mp4`），而非带授权的 `/api/share/file?id=...&share_token=...` URL。

本 PR 解决了以上两个缺陷，使得含有HTML 媒体标签的笔记能在分享视图中正常加载。

**What changed**

- 新增三个与 `htmlImageRegex` 捕获形状完全一致的正则表达式：`htmlVideoRegex`、`htmlAudioRegex`、`htmlSourceRegex`，并收拢到包级变量 `htmlMediaRegexes` 切片中供统一迭代。
- `extractSharedNoteFileRefs` 中增加对 `htmlMediaRegexes` 的遍历，对每个匹配到的 `src` 应用 `isLocalSharePath` 校验和去重逻辑，将其纳入文件引用映射表。
- 新增 `rewriteHTMLMediaSources(content, re, tagName, fileRefs, shareToken, password)` 辅助函数，对匹配到的媒体标签执行 src 替换为分享 API URL 的操作。自闭合 `<source ... />` 的尾部斜杠会被保留在 `afterSrc` 组中，从而在替换后仍然保持自闭合形态。
- 在 `GetSharedNote` 流程中，于 `rewriteHTMLImageSources` 之后依次调用 `rewriteHTMLMediaSources`（分别传入 video/audio/source 的正则），完成分享视图的 src 重写。

在 `rewriteMarkdownImageLinks` 里增加了 `detectMediaKindByExt(file.Path)` 分发：
- 视频 → 输出 `<video src="..." controls style="max-width:100%"></video>`
- 音频 → 输出 `<audio src="..." controls></audio>`
- 图片 → 保持原来的 `![alt](url)` 形式不变


**其他影响：普通登录流程**

`fileService.ResolveEmbedLinks` 复用了 `extractSharedNoteFileRefs`，因此登录用户在查看自己的笔记时，`<video>`/`<audio>`/`<source>` 中的媒体路径也会被正确提取到 `fileLinks` 中。配套的前端 PR 会消费这些 entries，将 src 替换为 `/api/file?vault=&path=&token=` 格式的授权 URL。登录用户原本就可以通过自己的 auth token 访问任何路径，因此这只是一个“能正常加载”的改进，不涉及权限变更。

**兼容性**

- 现有 `<img>` 处理管道完全未动。
- `attachmentRegex`、`markdownImageRegex` 的提取与重写不变。
- `isLocalSharePath`、`mergeShareFileResources`、`buildSharedFileAPIURL` 不变。
- 无数据层或 schema 变更。

---

## 测试

对于以下视频和音频链接：

```
### 2. 标准 Markdown 超链接
视频：
![11](assets/v1.mp4)
![](assets/en%20space/v1.mp4)
![](assets/中文/v1.mp4)
![](assets/中文%20有空格/v1.mp4)

音频：
![](assets/a1.mp3)
![](assets/en%20space/a1.mp3)
![](assets/中文/a1.mp3)
![](assets/中文%20有空格/a1.mp3)

### 3. HTML 标签
<!-- 视频 -->
<!-- 路径 assets/ -->
<video src="assets/v1.mp4" controls width="500"></video>
<!-- 路径 assets/en space/ -->
<video src="assets/en space/v1.mp4" controls width="500"></video>
<!-- 路径 assets/中文/ -->
<video src="assets/中文/v1.mp4" controls width="500"></video>
<!-- 路径 assets/中文 有空格/ -->
<video src="assets/中文 有空格/v1.mp4" controls width="500"></video>


<!-- 音频 -->
<!-- 路径 assets/ -->
<audio src="assets/a1.mp3" controls></audio>
<!-- 路径 assets/en space/ -->
<audio src="assets/en space/a1.mp3" controls></audio>
<!-- 路径 assets/中文/ -->
<audio src="assets/中文/a1.mp3" controls></audio>
<!-- 路径 assets/中文 有空格/ -->
<audio src="assets/中文 有空格/a1.mp3" controls></audio>
```

修复前：
<img width="567" height="343" alt="2026-05-26_022532" src="https://github.com/user-attachments/assets/d49cd099-665d-438e-8f99-75c69da4fd19" />

修复后：
<img width="552" height="3112" alt="2026-05-26_023032" src="https://github.com/user-attachments/assets/2c36305f-71a7-4b01-ab0b-63e6106a92f8" />
