### PR TITLE
fix(upgrade): add HTTP timeout context and use configured TempPath

### DIFF
--- a/internal/routers/api_router/handler_admin_control.go
+++ b/internal/routers/api_router/handler_admin_control.go
@@ -3,6 +3,7 @@ package api_router
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -926,8 +927,8 @@ func (h *AdminControlHandler) Upgrade(c *gin.Context) {
 	h.App.Logger().Info("Starting upgrade download", zap.String("url", downloadURL), zap.String("version", versionRaw))
 
 	// Prepare temp directory
-	// 使用 storage/temp/upgrade 作为临时目录
-	tempDir := filepath.Join("storage", "temp", "upgrade")
+	// 使用配置中的 TempPath 作为临时目录
+	tempDir := filepath.Join(cfg.App.TempPath, "upgrade")
 	_ = os.RemoveAll(tempDir)
 	if err := os.MkdirAll(tempDir, 0755); err != nil {
 		response.ToResponse(code.Failed.WithDetails("Failed to create temp directory: " + err.Error()))
@@ -936,7 +937,11 @@ func (h *AdminControlHandler) Upgrade(c *gin.Context) {
 
 	// Download
 	tarPath := filepath.Join(tempDir, fileName)
-	if err := h.downloadFile(downloadURL, tarPath); err != nil {
+	if err := h.downloadFile(c.Request.Context(), downloadURL, tarPath); err != nil {
+		h.App.Logger().Error("Upgrade download failed",
+			zap.String("url", downloadURL),
+			zap.Error(err),
+		)
 		response.ToResponse(code.Failed.WithDetails("Download failed: " + err.Error()))
 		return
 	}
@@ -949,6 +954,7 @@ func (h *AdminControlHandler) Upgrade(c *gin.Context) {
 	extractedBinaryPath := filepath.Join(tempDir, binaryName)
 
 	if err := h.extractBinary(tarPath, tempDir, binaryName); err != nil {
+		h.App.Logger().Error("Upgrade extract failed", zap.Error(err))
 		response.ToResponse(code.Failed.WithDetails("Extract failed: " + err.Error()))
 		return
 	}
@@ -1113,10 +1119,24 @@ func (h *AdminControlHandler) KickWSClient(c *gin.Context) {
 	response.ToResponse(code.Success.WithDetails("Client kicked successfully"))
 }
 
-func (h *AdminControlHandler) downloadFile(url string, dest string) error {
-	resp, err := http.Get(url)
+func (h *AdminControlHandler) downloadFile(ctx context.Context, url string, dest string) error {
+	client := &http.Client{
+		Timeout: 3 * time.Minute,
+		Transport: &http.Transport{
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 60 * time.Second,
+        	IdleConnTimeout:       90 * time.Second,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("create request failed: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -1126,12 +1146,16 @@ func (h *AdminControlHandler) downloadFile(url string, dest string) error {
 
 	out, err := os.Create(dest)
 	if err != nil {
-		return err
+		return fmt.Errorf("create file failed: %w", err)
 	}
 	defer out.Close()
 
 	_, err = io.Copy(out, resp.Body)
-	return err
+	if err != nil {
+		return fmt.Errorf("save file failed: %w", err)
+	}
+
+	return nil
 }
 
 func (h *AdminControlHandler) extractBinary(tarPath string, destDir string, binaryName string) error {


### PR DESCRIPTION
## Summary / 概述

https://github.com/haierkeys/fast-note-sync-service/issues/263 反馈的问题表现为在 WebGUI 中点击升级一直转圈，不成功也不显示失败。
本 PR 修复服务端在线升级功能中 `downloadFile` 无超时导致永久挂起的问题。
会产生如下的超长挂起时间：
```
[GIN] 2026/04/27 - 19:53:47 | 200 | 1h39m40s |   x.x.x.x | GET      "/api/admin/upgrade?version=latest&_t=1777284840810&_r=prhk8s"
```

## Changes / 变更内容

- **`downloadFile` 方法重构**：添加 `context.Context` 参数，通过 `http.NewRequestWithContext` 传递 Gin 请求上下文；使用自定义 `http.Client`，设置总超时 3 分钟、TLS 握手超时 30 秒、响应头超时 60 秒、空闲连接超时 90 秒；所有错误使用 `%w` 包装保留错误链
- **`Upgrade` handler 调整**：传递 `c.Request.Context()` 使下载与 Gin 请求上下文联动；下载和解压失败时增加 Error 级别日志
- **临时目录路径修复**：从硬编码 `"storage/temp/upgrade"` 改为 `cfg.App.TempPath + "/upgrade"`，尊重用户自定义配置
- **导入 `"context"` 包**：支持 `http.NewRequestWithContext` 调用

## Test Plan / 测试方式

**自测**：网络不超时场景正常升级；超时场景按照预期报错并在日志中打印。
WebGUI 中升级显示错误
<img width="280" height="107" alt="2026-06-07_132008" src="https://github.com/user-attachments/assets/1b6ede9b-d01b-4863-b0d4-8adb2470ec93" />

```
2026-06-07T13:19:05.918+0800    ERROR   Upgrade download failed {"url": "https://github.com/haierkeys/fast-note-sync-service/releases/download/3.2.3/fast-note-sync-service-3.2.3-windows-amd64.tar.gz", "error": "save file failed: context deadline exceeded"}
[GIN] 2026/06/07 - 13:19:05 | 200 |     1m0s |       127.0.0.1 | GET      "/api/admin/upgrade?version=latest&_=1780809485916_w5zftlg7du&lang=zh-CN"
2026-06-07T13:20:05.921+0800    ERROR   Upgrade download failed {"url": "https://github.com/haierkeys/fast-note-sync-service/releases/download/3.2.3/fast-note-sync-service-3.2.3-windows-amd64.tar.gz", "error": "save file failed: context deadline exceeded"}
[GIN] 2026/06/07 - 13:20:05 | 200 |     1m0s |       127.0.0.1 | GET      "/api/admin/upgrade?version=latest&_=1780809485916_w5zftlg7du&lang=zh-CN"
```

## Related Issue / 关联 Issue

https://github.com/haierkeys/fast-note-sync-service/issues/263