### PR TITLE
fix(service): move `/api/admin/check` to auth group to fix plugin `isAdmin` always false

### DIFF
--- a/internal/routers/router_api.go
+++ b/internal/routers/router_api.go
@@ -99,6 +99,7 @@ func registerAPIRoutes(r *gin.Engine, appContainer *app.App, wss *pkgapp.Websock
 			// Admin config interface
 			// 管理员配置接口
 			auth.GET("/admin/upgrade", adminControlHandler.Upgrade)
+			auth.GET("/admin/check", adminControlHandler.CheckAdmin)
 			auth.GET("/admin/ws_clients", adminControlHandler.GetWSClients)
 			auth.DELETE("/admin/ws_client/:traceId", adminControlHandler.KickWSClient)
 
@@ -173,7 +174,6 @@ func registerAPIRoutes(r *gin.Engine, appContainer *app.App, wss *pkgapp.Websock
 
 				// Admin config interface
 				// 管理员配置接口
-				webguiGroup.GET("/admin/check", adminControlHandler.CheckAdmin)
 				webguiGroup.GET("/admin/config", adminControlHandler.GetConfig)
 				webguiGroup.POST("/admin/config", adminControlHandler.UpdateConfig)
 				webguiGroup.GET("/admin/config/user_database", adminControlHandler.GetUserDatabaseConfig)


### PR DESCRIPTION
## Summary / 概述

修复 Obsidian 插件端因 `/api/admin/check` 接口被错误放入 `webguiGroup`，导致该接口被 `RequireWebGUI()` 中间件拦截，`isAdmin` 始终为 `false`，无法显示“升级服务端”按钮的问题。  

## 问题描述及原因

### 问题表现
在 Obsidian 插件中打开服务端版本弹窗（`AboutModal`）时，`canUpgrade={serverIsNew && isAdmin}` 中的 `isAdmin` 始终为 `false`，导致即使有新版且已登录也无法显示升级按钮。

### 根本原因

| 环节         | 说明                                                         |
| ------------ | ------------------------------------------------------------ |
| 权限检查链路 | 插件调用 `plugin.api.checkAdmin()` → `GET /api/admin/check`，请求头携带 `x-client: ObsidianPlugin` |
| 路由注册     | `router_api.go:173` 将该接口注册在 `webguiGroup` 组下        |
| 中间件       | `webguiGroup` 使用 `RequireWebGUI()` 中间件，该中间件要求 `x-client` 必须为 `"webgui"` |
| 拒绝逻辑     | `x-client` 不匹配 → 返回 `ErrorAuthTokenClientRestricted`    |
| 插件处理     | `http_api_service.ts:240-242` catch 错误后返回 `false` → `setIsAdmin(false)` |

**核心矛盾**：服务端升级接口 `/admin/upgrade` 本身不受 `RequireWebGUI` 限制（注册在 `auth` 组），插件可以正常调用；但检查权限的 `/admin/check` 却被放在 `webguiGroup` 中，导致插件请求永远被拦截。

## Changes / 变更内容

- 将 `GET /admin/check` 从 `webguiGroup` 路由组移至 `auth` 路由组，与 `/admin/upgrade` 等其他管理员端点放在一起。  
- 删除 `webguiGroup` 中原有的 `/admin/check` 注册行。  
- 涉及文件：`fast-note-sync-service/internal/routers/router_api.go`

```diff
- webguiGroup.GET("/admin/check", adminControlHandler.CheckAdmin)
+ auth.GET("/admin/check", adminControlHandler.CheckAdmin)
```

## Test / 测试
修复前：无升级按钮
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/826f348d-1682-465f-9529-739f3ce0d6e8" />

 修复后：
<img width="500" alt="image" src="https://github.com/user-attachments/assets/fe2f89f0-b181-477c-87db-dccad38cfcc0" />
