### PR TITLE
fix: Resolve protobuf decoding failure in ClientInfo handler causing Code=305 on strategy change

### DIFF
--- a/pkg/app/websocket.go
+++ b/pkg/app/websocket.go
@@ -1039,9 +1039,9 @@ func (w *WebsocketServer) Authorization(c *WebsocketClient, msg *WebSocketMessag
 
 func (w *WebsocketServer) ClientInfo(c *WebsocketClient, msg *WebSocketMessage) {
 	var info ClientInfoMessage
-	if err := json.Unmarshal(msg.Data, &info); err != nil {
-		log(LogError, "WS ClientInfo Unmarshal FAILD", zap.Error(err))
-		c.ToResponse(code.ErrorInvalidParams.WithDetails(err.Error()))
+	if ok, errs := c.BindAndValidWithAction(msg.Type, msg.Data, &info); !ok {
+		log(LogError, "WS ClientInfo Unmarshal FAILD", zap.Error(fmt.Errorf(errs.ErrorsToString())))
+		c.ToResponse(code.ErrorInvalidParams.WithDetails(errs.ErrorsToString()))
 		return
 	}
 


### PR DESCRIPTION
## 概述

修复服务端 `ClientInfo` WebSocket handler 正确解码 protobuf 编码的消息，解决插件启用 protobuf 协议后，修改设置中的离线编辑合并策略时出现 "Code=305 参数验证失败" 错误。

## 问题描述及原因

**问题现象：** 用户在插件设置启用 protobuf 协议后，修改"离线编辑合并策略"（`offlineSyncStrategy`）时，插件调用 `sendClientInfo()` 通知服务端。服务端返回错误 `Code=305 Message=参数验证失败` 和 `Details="Syntax error at index 2: invalid char"`，导致设置变更失败。

错误截图：
<img width="793" height="493" alt="2026-06-12_035552" src="https://github.com/user-attachments/assets/3a548009-c075-489f-b432-61aeb8f33100" />

错误信息：

```
Service Error: Code=305 Message=参数验证失败 Details="Syntax error at index 2: invalid char\n\n\t\n\x03Win\x12\x052.1.8\x1a\x0eObsidianPlugin \x01(\x00\n\t.^......\n"
```

**根本原因：** 服务端 `ClientInfo` handler（`pkg/app/websocket.go:1040`）直接使用 `json.Unmarshal(msg.Data, &info)` 解析传入数据。但启用 protobuf 后：

1. 客户端首次以 JSON 文本帧发送 `ClientInfo` — 成功
2. 服务端返回成功，客户端升级到 protobuf 模式
3. 后续 `sendClientInfo()` 调用（如修改合并策略时），客户端发送 protobuf 编码的二进制数据
4. 服务端收到 protobuf 数据后，handler 尝试对原始 protobuf 字节执行 `json.Unmarshal`，失败并报 "Syntax error at index 2: invalid char"
5. 服务端返回 `ErrorInvalidParams`（Code=305）

其他 WebSocket handler（如 `NoteModify`、`SettingModify`）正确使用 `c.BindAndValidWithAction(msg.Type, msg.Data, params)`，当 `c.UseProtobuf` 为 true 时自动通过 `ProtobufDecoder` 选择 protobuf 解码，否则回退到 JSON 解码。`ClientInfo` handler 是唯一使用原生 `json.Unmarshal` 的。

**影响范围：** 此 bug 自服务端引入 protobuf 支持（v3.2.3，commit `8093743d`）起就已存在，但仅在插件端启用 protobuf 协议后（v2.1.6，commit `a30a858`）才暴露。受影响版本：插件 ≥2.1.6，服务端 ≥3.2.3。

## 变更内容

- **`pkg/app/websocket.go`**：将 `ClientInfo` handler 中的 `json.Unmarshal(msg.Data, &info)` 替换为 `c.BindAndValidWithAction(msg.Type, msg.Data, &info)`，与代码库中所有其他 WebSocket handler 保持一致。同时补回了 `"WS ClientInfo Unmarshal FAILD"` 错误日志行。

## 测试

**自测：** protobuf 启用状态下，在插件设置中修改离线编辑合并策略不再触发 Code=305
