### PR TITLE
fix: WebSocket connections not properly closed during server graceful shutdown causing write queue errors

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -588,7 +588,21 @@ func (a *App) Shutdown(ctx context.Context) error {
 
 	var errs []error
 
-	// 0. Shutdown ShareService (sync final statistics)
+	// 0. Close all WebSocket connections and wait for handlers to finish.
+	// This must happen before Worker Pool and Write Queue Manager shutdown
+	// to prevent "write queue is closed" and "worker pool is closed" errors
+	// from zombie WebSocket handlers using closed resources.
+	// 关闭所有 WebSocket 连接并等待处理器完成。
+	// 必须在 Worker Pool 和 Write Queue Manager 关闭之前执行，
+	// 以防止僵尸 WebSocket 处理器使用已关闭的资源导致错误。
+	if a.wss != nil {
+		a.logger.Info("Closing all WebSocket connections...")
+		a.wss.CloseAllConnections()
+		a.wss.WaitAllClosed(10 * time.Second)
+		a.logger.Info("All WebSocket connections closed")
+	}
+
+	// 0.1 Shutdown ShareService (sync final statistics)
 	// 0. 关闭 ShareService（同步最后的统计数据）
 	if a.ShareService != nil {
 		a.logger.Info("Shutting down share service...")

--- a/pkg/app/websocket.go
+++ b/pkg/app/websocket.go
@@ -727,6 +727,7 @@ type WebsocketServer struct {
 	binaryHandlers    map[string]func(*WebsocketClient, []byte) // Binary message handler map: prefix -> handler // 二进制消息处理器映射 prefix -> handler
 	clients           ConnStorage
 	userClients       map[string]ConnStorage
+	connWg            sync.WaitGroup
 	mu                sync.RWMutex
 	up                *gws.Upgrader
 	config            *WSConfig
@@ -904,6 +905,7 @@ func (w *WebsocketServer) Run() gin.HandlerFunc {
 		client.initContext(traceID)
 
 		w.AddClient(client)
+		w.connWg.Add(1)
 		log(LogInfo, "WS Start",
 			zap.String("type", "ReadLoop"),
 			zap.String("traceID", traceID),
@@ -1226,6 +1228,44 @@ func (w *WebsocketServer) KickToken(uid int64, tokenID int64) {
 	}
 }
 
+// CloseAllConnections sends a close frame to all active WebSocket connections.
+// This must be called before shutting down the Worker Pool and Write Queue Manager
+// to ensure hijacked WebSocket connections are properly terminated.
+// 向所有活跃的 WebSocket 连接发送关闭帧。
+// 必须在关闭 Worker Pool 和 Write Queue Manager 之前调用，以确保被劫持的 WebSocket 连接被正确终止。
+func (w *WebsocketServer) CloseAllConnections() {
+	w.mu.RLock()
+	clients := make([]*WebsocketClient, 0, len(w.clients))
+	for _, c := range w.clients {
+		clients = append(clients, c)
+	}
+	w.mu.RUnlock()
+
+	for _, c := range clients {
+		if c.conn != nil {
+			_ = c.conn.WriteClose(1001, []byte("server shutting down"))
+		}
+	}
+}
+
+// WaitAllClosed waits for all WebSocket connections to be fully closed (OnClose completed).
+// Returns when all connections are closed or timeout is reached.
+// 等待所有 WebSocket 连接完全关闭（OnClose 回调执行完毕）。
+// 在所有连接关闭或超时后返回。
+func (w *WebsocketServer) WaitAllClosed(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		w.connWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		log(LogWarn, "WaitAllClosed: timeout waiting for WebSocket connections to close",
+			zap.Int("remaining", len(w.clients)))
+	}
+}
+
 func (w *WebsocketServer) RemoveUserClient(c *WebsocketClient) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -1335,6 +1375,7 @@ func isNormalDisconnectError(err error) bool {
 }
 
 func (w *WebsocketServer) OnClose(conn *gws.Conn, err error) {
+	defer w.connWg.Done()
 
 	c := w.GetClient(conn)
 	if c == nil {


### PR DESCRIPTION
## 概述

修复服务端热重载/优雅关闭时，已劫持的 WebSocket 连接未被正确关闭，导致旧的 WebSocket handler 继续使用已关闭的 Write Queue Manager 和 Worker Pool，产生 `write queue is closed` / `worker pool is closed` 错误的问题。

## 问题描述及原因

### 现象

- Obsidian 插件修改笔记触发 `Database query failed: write queue is closed`
- 重命名笔记/附件触发 `Note does not exist`
- 添加附件触发 `服务器繁忙 (worker pool is closed)`
- 错误在不重启 Obsidian 插件的情况下会一直持续，需要重启插件才能解决。

错误截图：
301错误

<img width="400" alt="file-20260527023212177" src="https://github.com/user-attachments/assets/40806cfb-f012-40c8-abc8-8a9ac8e4ba70" />

302错误

<img width="400"  alt="file-20260527023520922" src="https://github.com/user-attachments/assets/40ee7055-74d9-4280-8c64-e04595203584" />


服务端优雅关闭时（热重载、SIGTERM、管理面板重启等），`http.Server.Shutdown()` **无法关闭已被 gws 劫持的 WebSocket 连接**（Go 标准库行为：`Shutdown` 仅关闭 listeners 和非劫持连接）。

`SafeClose` 机制并发关闭所有组件：

| 组件 | 关闭操作 | 结果 |
|------|---------|------|
| HTTP Server | `Shutdown(5s)` | 无法关闭劫持连接，超时返回 |
| App Container | 关闭 Worker Pool → Write Queue Manager | 资源被释放 |

App Container 先于 WebSocket 连接完成关闭，旧的 WebSocket handler goroutine（由 `go socket.ReadLoop()` 启动，不受 `SafeClose` 管理）继续运行，使用已关闭的资源 → 报错。

### 复现方法

1. 启动服务端，连接 Obsidian 插件
2. 通过 WebGUI 管理面板修改配置（触发热重载）
3. 修改笔记 → 观察到 `write queue is closed` 错误

## 变更内容

- **`pkg/app/websocket.go`**
  - `WebsocketServer` 新增 `connWg sync.WaitGroup` 字段，跟踪所有活跃 WebSocket 连接生命周期
  - `Run()` 中在 `go socket.ReadLoop()` 之前调用 `connWg.Add(1)` 注册连接
  - `OnClose()` 中通过 `defer connWg.Done()` 在连接完全清理后释放计数
  - 新增 `CloseAllConnections()` 方法：向所有活跃连接发送 close frame (1001 "server shutting down")
  - 新增 `WaitAllClosed(timeout)` 方法：等待所有连接的 `OnClose` 回调完成，带超时保护
- **`internal/app/app.go`**
  - `Shutdown()` 第一步新增 WebSocket 关闭流程：先调用 `CloseAllConnections()` + `WaitAllClosed(10s)`，确保所有 WebSocket handler 退出后再关闭 Worker Pool 和 Write Queue Manager

### 修复后的关闭时序

```
T+0s   CloseAllConnections() → 发送 close frame 给所有 WS 连接
T+0~1s OnClose 回调触发 → cancelContext、清理资源、connWg.Done()
T+~1s  WaitAllClosed 返回（所有 WS handler 已退出）
T+1s   ShareService / Worker Pool / Write Queue Manager 安全关闭
```

## 测试

**自测**：
- 本地 Windows 环境通过 WebGUI 修改配置触发热重载，确认旧 WebSocket 连接被正确关闭，不再出现 `write queue is closed` 错误

修复前：

https://github.com/user-attachments/assets/7aa77600-ba9c-4257-b1c2-538fbf6f96af

修复后：

https://github.com/user-attachments/assets/b7e76425-0d2e-4caf-a5f2-8363f57d36d5


## 相关 Issue

https://github.com/haierkeys/fast-note-sync-service/issues/348