### PR TITLE
fix(mcp): add file_write output schema metadata

### DIFF
--- a/internal/middleware/user_auth_token_test.go
+++ b/internal/middleware/user_auth_token_test.go
@@ -47,6 +47,10 @@ func (s *fakeMiddlewareTokenService) Rotate(ctx context.Context, uid int64, toke
 	return nil, errors.New("not implemented")
 }
 
+func (s *fakeMiddlewareTokenService) RotateForLogin(ctx context.Context, uid int64, tokenID int64, ip, userAgent string) (*domain.AuthToken, string, error) {
+	return nil, "", errors.New("not implemented")
+}
+
 func (s *fakeMiddlewareTokenService) GetActiveToken(ctx context.Context, uid int64, tokenID int64) (*domain.AuthToken, error) {
 	return s.activeToken, s.activeErr
 }

--- a/internal/routers/mcp_router/file_tools.go
+++ b/internal/routers/mcp_router/file_tools.go
@@ -339,11 +339,12 @@ func registerFileTools(srv *mcpsrv.MCPServer, appContainer *app.App, wss *pkgapp
 	// 8. 写入文件（通过 MCP 新建或更新文件/附件）
 	toolWriteFile := mcp.NewTool("file_write",
 		mcp.WithDescription("Create or update a file (attachment) in the vault by uploading its base64 encoded content"),
+		mcp.WithOutputSchema[mcpFileWriteOutput](),
 		mcp.WithString("vault", mcp.Description("Vault name. Omitting this or providing 'default' will use the client-configured default vault.")),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Target file path in the vault (e.g. 'images/my_pic.png')")),
 		mcp.WithString("content", mcp.Required(), mcp.Description("Base64 encoded file content")),
 	)
-	srv.AddTool(toolWriteFile, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	srv.AddTool(writeMCPTool(toolWriteFile, cfg, false, "files:write"), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		if err := checkPermission(ctx, "file_w"); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -412,6 +413,9 @@ func registerFileTools(srv *mcpsrv.MCPServer, appContainer *app.App, wss *pkgapp
 			UpdatedTimestamp: fileDTO.UpdatedTimestamp,
 		}).WithVault(vault), "FileSyncUpdate")
 
-		return mcp.NewToolResultText(fmt.Sprintf("Successfully wrote file: %s (Size: %d bytes)", fileDTO.Path, fileDTO.Size)), nil
+		return mcp.NewToolResultStructured(mcpFileWriteOutput{
+			Vault: vault,
+			File:  fileDTO.ToMcpFileDTO(),
+		}, fmt.Sprintf("Successfully wrote file: %s (Size: %d bytes)", fileDTO.Path, fileDTO.Size)), nil
 	})
 }

--- a/internal/routers/mcp_router/tool_metadata_test.go
+++ b/internal/routers/mcp_router/tool_metadata_test.go
@@ -2,6 +2,10 @@ package mcp_router
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	appconfig "github.com/haierkeys/fast-note-sync-service/internal/app"
@@ -95,6 +99,58 @@ func TestToolMetadataMarshalIncludesSecuritySchemesAndAnnotations(t *testing.T) 
 	}
 	if writeTool.Annotations.DestructiveHint == nil || !*writeTool.Annotations.DestructiveHint {
 		t.Fatalf("write destructiveHint = %#v, want true", writeTool.Annotations.DestructiveHint)
+	}
+}
+
+func TestMCPToolDefinitionsDeclareOutputSchemasAndMetadata(t *testing.T) {
+	files := []string{"note_tools.go", "file_tools.go", "vault_tools.go"}
+	toolDefRE := regexp.MustCompile(`(\w+)\s*:=\s*mcp\.NewTool\("([^"]+)"`)
+	addToolRE := regexp.MustCompile(`srv\.AddTool\(([^,]+),`)
+
+	for _, file := range files {
+		path := filepath.Join(".", file)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		lines := strings.Split(string(raw), "\n")
+		toolNames := map[string]string{}
+
+		for i := 0; i < len(lines); i++ {
+			match := toolDefRE.FindStringSubmatch(lines[i])
+			if match == nil {
+				continue
+			}
+			varName := match[1]
+			toolName := match[2]
+			toolNames[varName] = toolName
+
+			block := lines[i]
+			for j := i + 1; j < len(lines); j++ {
+				block += "\n" + lines[j]
+				if strings.TrimSpace(lines[j]) == ")" {
+					i = j
+					break
+				}
+			}
+			if !strings.Contains(block, "mcp.WithOutputSchema[") {
+				t.Fatalf("%s: tool %s (%s) is missing mcp.WithOutputSchema", file, toolName, varName)
+			}
+		}
+
+		for i, line := range lines {
+			match := addToolRE.FindStringSubmatch(line)
+			if match == nil {
+				continue
+			}
+			expr := strings.TrimSpace(match[1])
+			if strings.HasPrefix(expr, "readOnlyMCPTool(") || strings.HasPrefix(expr, "writeMCPTool(") {
+				continue
+			}
+			if toolName, ok := toolNames[expr]; ok {
+				t.Fatalf("%s:%d: tool %s (%s) is missing MCP metadata wrapper", file, i+1, toolName, expr)
+			}
+		}
 	}
 }
 

--- a/internal/routers/mcp_router/tool_outputs.go
+++ b/internal/routers/mcp_router/tool_outputs.go
@@ -70,6 +70,11 @@ type mcpFileRecycleClearOutput struct {
 	Path  string `json:"path,omitempty"`
 }
 
+type mcpFileWriteOutput struct {
+	Vault string          `json:"vault"`
+	File  *dto.McpFileDTO `json:"file"`
+}
+
 type mcpVaultListOutput struct {
 	Count  int             `json:"count"`
 	Vaults []*dto.VaultDTO `json:"vaults"`


### PR DESCRIPTION
## Summary
- add an output schema for the MCP file_write tool
- wrap file_write with MCP write metadata so visibility/security annotations are emitted
- return a structured file_write result instead of text-only output
- add a regression test that all MCP tools declare output schemas and metadata wrappers
- update middleware test fake for the latest TokenService interface

## Validation
- go test ./internal/routers/mcp_router ./internal/routers ./internal/oauth ./internal/middleware
- make test