### PR TITLE
docs(mcp): add OAuth Stytch runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ FNS now natively supports **MCP (Model Context Protocol)** and provides both **S
 
 You can integrate FNS as an MCP server directly into compatible AI clients like Cherry Studio, Cursor, Claude Code, and hermes-agent. Once integrated, the AI will gain the ability to read and write your personal notes and attachments. In addition, all modifications made via MCP will be synchronized to your client devices in real-time via WebSocket.
 
+For OAuth-protected MCP deployments with Stytch, see [docs/runbook/mcp-oauth-stytch.md](docs/runbook/mcp-oauth-stytch.md) ([简体中文](docs/runbook/mcp-oauth-stytch.zh-CN.md), [繁體中文](docs/runbook/mcp-oauth-stytch.zh-TW.md)).
+
 ### Common Request Header Parameters
 
 The following request headers are supported regardless of the transport mode used:

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -226,6 +226,8 @@ FNS 现已原生支持 **MCP (Model Context Protocol)**，并同时提供 **SSE*
 
 您可以将 FNS 作为 MCP 服务端直接接入 Cherry Studio、Cursor、Claude Code、hermes-agent 等兼容的 AI 客户端。接入后，AI 即可具备读写私人笔记和附件的能力。同时，所有由 MCP 产生的修改，都会通过 WebSocket 实时同步到您的各个设备终端。
 
+如需使用 Stytch 配置受 OAuth 保护的 MCP 部署，请阅读 [MCP OAuth 与 Stytch 运行手册](runbook/mcp-oauth-stytch.zh-CN.md)。
+
 ### 通用请求头参数
 
 无论使用哪种传输模式，均支持以下请求头：

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -226,6 +226,8 @@ FNS 現已原生支援 **MCP (Model Context Protocol)**，並同時提供 **SSE*
 
 您可以將 FNS 作為 MCP 服務端直接接入 Cherry Studio、Cursor、Claude Code、hermes-agent 等相容的 AI 用戶端。接入後，AI 即可具備讀寫私人筆記和附件的能力。同時，所有由 MCP 產生的修改，都會透過 WebSocket 即時同步到您的各個裝置終端。
 
+如需使用 Stytch 設定受 OAuth 保護的 MCP 部署，請閱讀 [MCP OAuth 與 Stytch 運行手冊](runbook/mcp-oauth-stytch.zh-TW.md)。
+
 ### 通用請求標頭參數
 
 無論使用哪種傳輸模式，均支援以下請求標頭：

--- a/docs/runbook/mcp-oauth-stytch.md
+++ b/docs/runbook/mcp-oauth-stytch.md
@@ -1,0 +1,392 @@
+# MCP OAuth and Stytch runbook
+
+Languages: [English](mcp-oauth-stytch.md) | [简体中文](mcp-oauth-stytch.zh-CN.md) | [繁體中文](mcp-oauth-stytch.zh-TW.md)
+
+Purpose: configure Fast Note Sync Service as an OAuth-protected MCP resource for ChatGPT and other MCP clients that support OAuth.
+
+Read this when you need to enable MCP OAuth, configure Stytch as the authorization server, configure an FNS deployment, or troubleshoot ChatGPT connector authorization.
+
+This document does not cover WebGUI OIDC SSO login. The current implementation does not add a "Login with OIDC", "Login with Stytch", or "Login with Casdoor" button to the WebGUI, and it does not implement a WebGUI callback route such as `/api/user/auth/callback`.
+
+## What this implements
+
+The current OAuth implementation is for MCP access control.
+
+When `oauth.enabled` is true, `/api/mcp` and `/api/mcp/sse` become OAuth-aware protected resources:
+
+1. An unauthenticated MCP request receives `401 Unauthorized` with a `WWW-Authenticate` header.
+2. The challenge points the client to protected resource metadata, usually `/.well-known/oauth-protected-resource/api/mcp`.
+3. The metadata advertises this FNS deployment as the protected resource and lists the configured authorization server.
+4. ChatGPT or another OAuth-capable MCP client completes OAuth with that authorization server.
+5. The client sends later MCP requests with `Authorization: Bearer <access-token>`.
+6. FNS verifies the bearer JWT locally with the configured issuer, JWKS URL, audience/resource, and scopes.
+7. FNS maps the verified JWT subject to an FNS user and maps OAuth scopes to FNS MCP permissions.
+
+This matches the ChatGPT Apps SDK authentication model: after OAuth, ChatGPT attaches the access token to MCP requests, while the MCP server remains responsible for signature validation, issuer and audience checks, expiry checks, and scope enforcement.
+
+References:
+
+- OpenAI Apps SDK authentication: <https://developers.openai.com/apps-sdk/build/auth#implementing-token-verification>
+- OpenAI Apps SDK MCP overview: <https://developers.openai.com/apps-sdk/concepts/mcp-server#why-apps-sdk-standardises-on-mcp>
+- Stytch MCP Server: <https://stytch.com/docs/resources/workspace-management/stytch-mcp-server>
+- Stytch custom Connected Apps flow: <https://stytch.com/docs/connected-apps/build-custom-flow/getting-started-api>
+- Stytch B2B Start OAuth Authorization API: <https://stytch.com/docs/api-reference/b2b/api/connected-apps/consent-management/start-oauth-authorization>
+
+## What this does not implement
+
+This is not WebGUI OIDC SSO.
+
+The following are not supported by this implementation:
+
+- A WebGUI login button for generic OIDC providers such as Casdoor.
+- A WebGUI OIDC callback endpoint such as `/api/user/auth/callback`.
+- Automatic WebGUI user provisioning from an external OIDC login.
+- Replacing `/api/user/login` with Stytch, Casdoor, Pocket ID, or another OIDC provider.
+
+The `oauth` config block verifies bearer tokens for MCP requests. It does not change WebGUI login behavior.
+
+## Code paths
+
+The main code paths are:
+
+- `internal/config/oauth.go`: config schema, defaults, validation, and protected resource metadata.
+- `internal/routers/router_oauth_metadata.go`: OAuth protected resource metadata routes.
+- `internal/routers/router_mcp.go`: MCP routes protected by OAuth-aware middleware.
+- `internal/middleware/mcp_oauth.go`: mixed static-token/OAuth MCP authentication.
+- `internal/oauth/verifier.go`: JWT verification using issuer, audience, JWKS, expiry, and scopes.
+- `internal/oauth/subject_mapper.go`: JWT subject to FNS UID mapping.
+- `internal/oauth/scope_mapper.go`: OAuth scope to FNS MCP permission mapping.
+- `internal/oauth/stytch_client.go`: Stytch authorize start/submit API client.
+- `internal/routers/api_router/handler_stytch_oauth.go`: authenticated FNS endpoints that bridge the authorize page to Stytch.
+- `frontend/oauth-authorize.html`: OAuth authorize page built from the WebGUI.
+
+## Public endpoints
+
+With OAuth enabled, the deployment must expose these endpoints over HTTPS:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/api/mcp` | Streamable HTTP MCP endpoint. |
+| `/api/mcp/sse` | Legacy SSE MCP endpoint. |
+| `/.well-known/oauth-protected-resource/api/mcp` | Protected resource metadata for `/api/mcp`. |
+| `/.well-known/oauth-protected-resource` | Generic protected resource metadata endpoint. |
+| `/oauth/authorize` | Browser page used during the Stytch Connected App authorization flow. |
+| `/api/oauth/stytch/authorize/start` | Authenticated FNS API endpoint that calls Stytch authorize start. |
+| `/api/oauth/stytch/authorize/submit` | Authenticated FNS API endpoint that calls Stytch authorize submit. |
+
+The two `/api/oauth/stytch/*` endpoints require an existing FNS WebGUI login token. The authorize page asks the user to log in to FNS first if `localStorage.token` is missing.
+
+## Configuration reference
+
+Add or update the `oauth` block in `config.yaml`.
+
+```yaml
+oauth:
+  enabled: true
+  resource: "https://fns.example.com/api/mcp"
+  authorization-servers:
+    - "https://example.customers.stytch.com"
+  jwks-url: "https://example.customers.stytch.com/.well-known/jwks.json"
+  issuer: "https://example.customers.stytch.com"
+  audience: []
+  scopes-supported:
+    - notes:read
+    - notes:write
+    - files:read
+    - files:write
+    - vaults:read
+  required-scopes:
+    - notes:read
+    - files:read
+    - vaults:read
+  resource-name: "Fast Note Sync MCP"
+  allow-static-fns-token: true
+  default-client: "ChatGPT"
+  default-client-name: "ChatGPT"
+  default-client-version: ""
+  default-vault-name: "main"
+  default-fns-scope: ""
+  subject-mapping:
+    mode: "email_or_fixed_uid"
+    claim: "email"
+    fixed-uid: 1
+  stytch:
+    enabled: true
+    kind: "b2b"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    organization-id: "organization-live-..."
+    member-id: "member-live-..."
+```
+
+### Core OAuth fields
+
+| Field | Required when enabled | Description |
+| --- | --- | --- |
+| `enabled` | yes | Enables OAuth-aware MCP authentication and protected resource metadata. |
+| `resource` | yes | Protected resource identifier. For ChatGPT MCP, use the public MCP endpoint URL, for example `https://fns.example.com/api/mcp`. |
+| `authorization-servers` | yes | Authorization server issuer origins advertised to the MCP client. For Stytch, use the Stytch customer domain origin. |
+| `jwks-url` | yes | JWKS endpoint used by FNS to verify JWT signatures. |
+| `issuer` | yes | Expected JWT issuer. Must match the token `iss` claim. |
+| `audience` | no | Optional accepted JWT audiences. If empty, FNS uses `resource` as the expected audience. |
+| `scopes-supported` | no | Scopes advertised in protected resource metadata. Defaults to the standard FNS MCP scopes. |
+| `required-scopes` | no | Scopes every OAuth token must contain. Defaults to `notes:read`, `files:read`, and `vaults:read`. |
+| `resource-name` | no | Human-readable resource name in metadata. |
+| `allow-static-fns-token` | no | Keeps existing FNS static token MCP clients working when OAuth is enabled. Defaults to true. |
+
+Use `required-scopes: []` only when the authorization server or client does not issue the custom FNS scopes and you intentionally rely on FNS permission mapping or another deployment-level control. For stricter public deployments, keep explicit required scopes.
+
+### FNS identity and permission mapping
+
+| Field | Description |
+| --- | --- |
+| `subject-mapping.mode` | `email`, `fixed_uid`, or `email_or_fixed_uid`. |
+| `subject-mapping.claim` | JWT claim used when matching an existing FNS user by email. Defaults to `email`. |
+| `subject-mapping.fixed-uid` | FNS UID used by `fixed_uid` or as fallback for `email_or_fixed_uid`. |
+| `default-fns-scope` | If set, bypasses OAuth scope mapping and grants this FNS scope to verified OAuth requests. |
+| `default-client`, `default-client-name`, `default-client-version` | Default MCP client headers used when the request or token does not provide them. |
+| `default-vault-name` | Default vault name used by MCP operations when the request does not provide a vault. |
+
+For a single-user deployment, `fixed_uid` is the simplest option:
+
+```yaml
+subject-mapping:
+  mode: fixed_uid
+  fixed-uid: 1
+```
+
+For a multi-user deployment, prefer email mapping:
+
+```yaml
+subject-mapping:
+  mode: email
+  claim: email
+```
+
+The email claim must exist in the verified access token, and the corresponding FNS user must already exist.
+
+## Stytch setup
+
+Use Stytch Connected Apps as the authorization server. The FNS server does not implement a full OAuth authorization server by itself; it acts as an MCP protected resource and uses Stytch to issue tokens.
+
+### 1. Create or select a Stytch project
+
+Use either:
+
+- B2B project: recommended for controlled organization/member access.
+- Consumer project: usable for user-based access when organization/member identifiers are not needed.
+
+Record these values:
+
+- Stytch project ID.
+- Stytch project secret.
+- Stytch customer domain, for example `https://example.customers.stytch.com`.
+- For B2B, organization ID and member ID, unless the authorize flow will identify the member through a Stytch session.
+
+Store the project secret only in a secret manager, environment variable, or another private configuration mechanism. Do not commit the real secret to Git.
+
+### 2. Configure the Connected App
+
+In Stytch, create a Connected App for ChatGPT or the MCP client.
+
+Configure:
+
+- Redirect URI: the redirect URI required by the MCP client or ChatGPT connector setup.
+- Allowed scopes: include the FNS MCP scopes that the client will request, such as `notes:read`, `notes:write`, `files:read`, `files:write`, and `vaults:read`.
+- Authorization entry point: point the Connected App custom authorization flow to the FNS authorize page, for example `https://fns.example.com/oauth/authorize`.
+
+The authorize page parses OAuth query parameters such as `client_id`, `redirect_uri`, `response_type`, `scope`, `state`, `nonce`, `code_challenge`, and `code_challenge_method`. It then calls the authenticated FNS Stytch bridge endpoints.
+
+### Optional: configure Stytch through Stytch MCP
+
+Stytch also publishes its own MCP server at:
+
+```text
+https://mcp.stytch.dev/mcp
+```
+
+Stytch's MCP server can be used from an MCP-capable development environment to manage Stytch project configuration with natural language instead of clicking through the Dashboard. It still requires OAuth authorization for the Stytch workspace before it can read or modify workspace resources.
+
+When available, use Stytch MCP to inspect or configure:
+
+- Existing projects and whether the target project is B2B or Consumer.
+- Connected App client IDs and names.
+- Connected App redirect URIs.
+- Project public tokens and SDK settings, when relevant.
+- Workspace-level settings needed by Connected Apps.
+
+Even when Stytch MCP is available, keep the FNS `config.yaml` values as the source of truth for the FNS deployment. Stytch MCP configures Stytch; it does not update FNS service configuration.
+
+### 3. Match Stytch values in FNS
+
+For B2B:
+
+```yaml
+oauth:
+  stytch:
+    enabled: true
+    kind: "b2b"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    organization-id: "organization-live-..."
+    member-id: "member-live-..."
+```
+
+For Consumer:
+
+```yaml
+oauth:
+  stytch:
+    enabled: true
+    kind: "consumer"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    user-id-prefix: "fns:"
+```
+
+Consumer mode uses `stytch.user-id` if configured. Otherwise, it sends `stytch.user-id-prefix + <FNS UID>` to Stytch.
+
+## Step-by-step deployment
+
+1. Deploy FNS with HTTPS.
+
+   The public base URL must be stable, for example `https://fns.example.com`.
+
+2. Configure `server.ext-api-url`.
+
+   ```yaml
+   server:
+     ext-api-url: "https://fns.example.com"
+   ```
+
+3. Configure the Stytch Connected App and collect the domain, project ID, secret, and B2B organization/member IDs if used.
+
+4. Add the `oauth` config block.
+
+   Set `resource` to `https://fns.example.com/api/mcp`. Set `issuer`, `jwks-url`, and `authorization-servers` to the Stytch customer domain and JWKS URL.
+
+5. Store the Stytch secret securely.
+
+   Use your normal secret-management mechanism or a local uncommitted config file. Do not commit the real Stytch secret.
+
+6. Restart the FNS service.
+
+7. Verify protected resource metadata:
+
+   ```bash
+   curl -sS https://fns.example.com/.well-known/oauth-protected-resource/api/mcp
+   ```
+
+   Expected result:
+
+   ```json
+   {
+     "resource": "https://fns.example.com/api/mcp",
+     "authorization_servers": ["https://example.customers.stytch.com"],
+     "scopes_supported": ["notes:read", "notes:write", "files:read", "files:write", "vaults:read"],
+     "bearer_methods_supported": ["header"],
+     "resource_name": "Fast Note Sync MCP",
+     "jwks_uri": "https://example.customers.stytch.com/.well-known/jwks.json"
+   }
+   ```
+
+8. Verify the MCP challenge:
+
+   ```bash
+   curl -i https://fns.example.com/api/mcp
+   ```
+
+   Expected result:
+
+   ```http
+   HTTP/2 401
+   WWW-Authenticate: Bearer resource_metadata="https://fns.example.com/.well-known/oauth-protected-resource/api/mcp" resource="https://fns.example.com/api/mcp", error="invalid_token"
+   ```
+
+9. Add the MCP server in ChatGPT or another OAuth-capable MCP client.
+
+   Use the MCP endpoint:
+
+   ```text
+   https://fns.example.com/api/mcp
+   ```
+
+   The client should discover the protected resource metadata and begin the OAuth flow with Stytch.
+
+10. During authorization, log in to FNS if the authorize page asks for an FNS login.
+
+    This is required because the FNS authorize bridge endpoints are protected by the existing FNS WebGUI token.
+
+11. After consent, confirm the MCP client can list and call tools.
+
+## Static token compatibility
+
+If `allow-static-fns-token: true`, existing MCP clients can continue using an FNS static token:
+
+```http
+Authorization: Bearer <fns-token>
+```
+
+This compatibility path is useful during migration because OAuth-capable clients and older token-only clients can coexist.
+
+If you want OAuth-only MCP access, set:
+
+```yaml
+oauth:
+  allow-static-fns-token: false
+```
+
+## Troubleshooting
+
+### ChatGPT says the MCP server does not implement OAuth
+
+Check that:
+
+- `oauth.enabled` is true.
+- `https://fns.example.com/.well-known/oauth-protected-resource/api/mcp` returns HTTP 200.
+- `https://fns.example.com/api/mcp` returns `401` with a `WWW-Authenticate` header that includes `resource_metadata`.
+- `oauth.resource` exactly matches the public MCP endpoint URL.
+- The ingress exposes `/.well-known/oauth-protected-resource/api/mcp`.
+
+### Metadata is missing `authorization_servers`
+
+Check `oauth.authorization-servers`. It must contain at least one authorization server origin.
+
+### Token verification fails with `invalid_token`
+
+Check:
+
+- The token `iss` claim matches `oauth.issuer`.
+- `oauth.jwks-url` is reachable by the FNS pod.
+- The signing key appears in the JWKS response.
+- The token has not expired.
+- `oauth.audience` or `oauth.resource` matches the token audience/resource.
+
+### Token verification fails with `insufficient_scope`
+
+Check:
+
+- The token contains every scope listed in `oauth.required-scopes`.
+- The Stytch Connected App is allowed to issue the requested FNS scopes.
+- `default-fns-scope` is intentionally unset or set to the expected FNS permission scope.
+
+### The WebGUI has no OIDC login button
+
+This is expected. The current implementation does not provide WebGUI OIDC SSO. It only protects MCP routes and provides an OAuth authorization bridge for MCP clients.
+
+### `/api/user/auth/callback` returns 404
+
+This is expected. That endpoint is not implemented.
+
+### Stytch authorize start or submit fails
+
+Check:
+
+- `oauth.stytch.enabled` is true.
+- `oauth.stytch.domain`, `project-id`, and `secret` are configured.
+- For `kind: b2b`, both `organization-id` and `member-id` are configured.
+- The Stytch Connected App allows the incoming `client_id`, `redirect_uri`, and scopes.
+- The user is logged in to FNS before using `/oauth/authorize`.

--- a/docs/runbook/mcp-oauth-stytch.zh-CN.md
+++ b/docs/runbook/mcp-oauth-stytch.zh-CN.md
@@ -1,0 +1,314 @@
+# MCP OAuth 与 Stytch 运行手册
+
+语言：[English](mcp-oauth-stytch.md) | [简体中文](mcp-oauth-stytch.zh-CN.md) | [繁體中文](mcp-oauth-stytch.zh-TW.md)
+
+用途：将 Fast Note Sync Service 配置为受 OAuth 保护的 MCP 资源，供 ChatGPT 和其他支持 OAuth 的 MCP 客户端访问。
+
+当你需要启用 MCP OAuth、把 Stytch 配置为授权服务器、配置 FNS 部署，或者排查 ChatGPT connector 授权问题时，阅读本文。
+
+本文不覆盖 WebGUI OIDC SSO 登录。当前实现不会在 WebGUI 中新增“使用 OIDC 登录”、“使用 Stytch 登录”或“使用 Casdoor 登录”的按钮，也没有实现 `/api/user/auth/callback` 这类 WebGUI 回调路由。
+
+## 当前实现目标
+
+当前 OAuth 实现的目标是 MCP 访问控制。
+
+当 `oauth.enabled` 为 `true` 时，`/api/mcp` 和 `/api/mcp/sse` 会成为支持 OAuth 的受保护资源：
+
+1. 未认证的 MCP 请求会收到 `401 Unauthorized`，响应中包含 `WWW-Authenticate` header。
+2. 这个 challenge 会指向 protected resource metadata，通常是 `/.well-known/oauth-protected-resource/api/mcp`。
+3. metadata 会声明当前 FNS 部署是受保护资源，并列出配置的授权服务器。
+4. ChatGPT 或其他支持 OAuth 的 MCP 客户端会到该授权服务器完成 OAuth。
+5. 客户端后续请求 MCP 时会带上 `Authorization: Bearer <access-token>`。
+6. FNS 使用配置中的 issuer、JWKS URL、audience/resource 和 scopes 本地验证 bearer JWT。
+7. FNS 将验证后的 JWT subject 映射到 FNS 用户，并将 OAuth scopes 映射为 FNS MCP 权限。
+
+这符合 ChatGPT Apps SDK 的认证模型：OAuth 完成后，ChatGPT 会把 access token 附加到 MCP 请求中；MCP server 仍然负责 token 签名验证、issuer/audience 校验、过期时间校验和 scope enforcement。
+
+参考资料：
+
+- OpenAI Apps SDK authentication: <https://developers.openai.com/apps-sdk/build/auth#implementing-token-verification>
+- OpenAI Apps SDK MCP overview: <https://developers.openai.com/apps-sdk/concepts/mcp-server#why-apps-sdk-standardises-on-mcp>
+- Stytch MCP Server: <https://stytch.com/docs/resources/workspace-management/stytch-mcp-server>
+- Stytch custom Connected Apps flow: <https://stytch.com/docs/connected-apps/build-custom-flow/getting-started-api>
+- Stytch B2B Start OAuth Authorization API: <https://stytch.com/docs/api-reference/b2b/api/connected-apps/consent-management/start-oauth-authorization>
+
+## 当前不支持什么
+
+这不是 WebGUI OIDC SSO。
+
+当前实现不支持：
+
+- 给 WebGUI 增加 Casdoor 等通用 OIDC provider 的登录按钮。
+- WebGUI OIDC callback endpoint，例如 `/api/user/auth/callback`。
+- 通过外部 OIDC 登录自动创建或映射 WebGUI 用户。
+- 用 Stytch、Casdoor、Pocket ID 或其他 OIDC provider 替换 `/api/user/login`。
+
+`oauth` 配置块用于验证 MCP 请求中的 bearer token，不会改变 WebGUI 登录行为。
+
+## 相关代码路径
+
+- `internal/config/oauth.go`：配置结构、默认值、校验逻辑和 protected resource metadata。
+- `internal/routers/router_oauth_metadata.go`：OAuth protected resource metadata 路由。
+- `internal/routers/router_mcp.go`：受 OAuth-aware middleware 保护的 MCP 路由。
+- `internal/middleware/mcp_oauth.go`：MCP static token 与 OAuth 混合认证。
+- `internal/oauth/verifier.go`：使用 issuer、audience、JWKS、过期时间和 scopes 验证 JWT。
+- `internal/oauth/subject_mapper.go`：JWT subject 到 FNS UID 的映射。
+- `internal/oauth/scope_mapper.go`：OAuth scope 到 FNS MCP 权限的映射。
+- `internal/oauth/stytch_client.go`：Stytch authorize start/submit API client。
+- `internal/routers/api_router/handler_stytch_oauth.go`：将 authorize page 桥接到 Stytch 的已认证 FNS API。
+- `frontend/oauth-authorize.html`：由 WebGUI 构建出的 OAuth authorize page。
+
+## 对外端点
+
+启用 OAuth 后，部署必须通过 HTTPS 暴露这些端点：
+
+| Endpoint | 用途 |
+| --- | --- |
+| `/api/mcp` | Streamable HTTP MCP endpoint。 |
+| `/api/mcp/sse` | 旧版 SSE MCP endpoint。 |
+| `/.well-known/oauth-protected-resource/api/mcp` | `/api/mcp` 的 protected resource metadata。 |
+| `/.well-known/oauth-protected-resource` | 通用 protected resource metadata endpoint。 |
+| `/oauth/authorize` | Stytch Connected App 授权流程使用的浏览器页面。 |
+| `/api/oauth/stytch/authorize/start` | 已认证 FNS API，会调用 Stytch authorize start。 |
+| `/api/oauth/stytch/authorize/submit` | 已认证 FNS API，会调用 Stytch authorize submit。 |
+
+两个 `/api/oauth/stytch/*` endpoint 都需要已有的 FNS WebGUI login token。如果浏览器中没有 `localStorage.token`，authorize page 会先要求用户登录 FNS。
+
+## 配置参考
+
+在 `config.yaml` 中新增或更新 `oauth` 配置块：
+
+```yaml
+oauth:
+  enabled: true
+  resource: "https://fns.example.com/api/mcp"
+  authorization-servers:
+    - "https://example.customers.stytch.com"
+  jwks-url: "https://example.customers.stytch.com/.well-known/jwks.json"
+  issuer: "https://example.customers.stytch.com"
+  audience: []
+  scopes-supported:
+    - notes:read
+    - notes:write
+    - files:read
+    - files:write
+    - vaults:read
+  required-scopes:
+    - notes:read
+    - files:read
+    - vaults:read
+  resource-name: "Fast Note Sync MCP"
+  allow-static-fns-token: true
+  default-client: "ChatGPT"
+  default-client-name: "ChatGPT"
+  default-client-version: ""
+  default-vault-name: "main"
+  default-fns-scope: ""
+  subject-mapping:
+    mode: "email_or_fixed_uid"
+    claim: "email"
+    fixed-uid: 1
+  stytch:
+    enabled: true
+    kind: "b2b"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    organization-id: "organization-live-..."
+    member-id: "member-live-..."
+```
+
+### 核心 OAuth 字段
+
+| 字段 | 启用后是否必填 | 说明 |
+| --- | --- | --- |
+| `enabled` | 是 | 启用 MCP OAuth-aware authentication 和 protected resource metadata。 |
+| `resource` | 是 | 受保护资源标识。ChatGPT MCP 场景下使用公开 MCP endpoint，例如 `https://fns.example.com/api/mcp`。 |
+| `authorization-servers` | 是 | 暴露给 MCP 客户端的授权服务器 origin。Stytch 场景下使用 Stytch customer domain origin。 |
+| `jwks-url` | 是 | FNS 用来验证 JWT 签名的 JWKS endpoint。 |
+| `issuer` | 是 | 期望的 JWT issuer，必须匹配 token 的 `iss` claim。 |
+| `audience` | 否 | 可选的 JWT audience 列表。为空时，FNS 使用 `resource` 作为期望 audience。 |
+| `scopes-supported` | 否 | 写入 protected resource metadata 的 scopes。默认是 FNS MCP 标准 scopes。 |
+| `required-scopes` | 否 | 每个 OAuth token 必须包含的 scopes。默认是 `notes:read`、`files:read` 和 `vaults:read`。 |
+| `resource-name` | 否 | metadata 中展示的人类可读资源名。 |
+| `allow-static-fns-token` | 否 | 启用 OAuth 时是否继续允许原有 FNS static token MCP 客户端访问。默认 true。 |
+
+只有在授权服务器或客户端无法签发 FNS 自定义 scopes，并且你明确希望依赖 FNS permission mapping 或部署层控制时，才使用 `required-scopes: []`。更严格的公网部署应保留显式 required scopes。
+
+### FNS 身份与权限映射
+
+| 字段 | 说明 |
+| --- | --- |
+| `subject-mapping.mode` | `email`、`fixed_uid` 或 `email_or_fixed_uid`。 |
+| `subject-mapping.claim` | 通过邮箱匹配 FNS 用户时读取的 JWT claim，默认 `email`。 |
+| `subject-mapping.fixed-uid` | `fixed_uid` 模式使用的 FNS UID，或 `email_or_fixed_uid` 模式的 fallback UID。 |
+| `default-fns-scope` | 如果设置，则跳过 OAuth scope mapping，直接给已验证 OAuth 请求授予该 FNS scope。 |
+| `default-client`, `default-client-name`, `default-client-version` | 请求或 token 没提供客户端信息时使用的默认 MCP client headers。 |
+| `default-vault-name` | MCP 操作未提供 vault 参数时使用的默认笔记库名称。 |
+
+单用户部署最简单的配置是 `fixed_uid`：
+
+```yaml
+subject-mapping:
+  mode: fixed_uid
+  fixed-uid: 1
+```
+
+多用户部署建议使用 email mapping：
+
+```yaml
+subject-mapping:
+  mode: email
+  claim: email
+```
+
+被验证的 access token 中必须存在对应 email claim，并且 FNS 中必须已经存在该用户。
+
+## Stytch 配置
+
+使用 Stytch Connected Apps 作为授权服务器。FNS server 自身不是完整 OAuth authorization server；它是 MCP protected resource，并使用 Stytch 签发 token。
+
+### 1. 创建或选择 Stytch project
+
+可选类型：
+
+- B2B project：推荐用于受控的 organization/member 访问。
+- Consumer project：适用于不需要 organization/member 标识的用户访问。
+
+记录这些值：Stytch project ID、Stytch project secret、Stytch customer domain，以及 B2B 场景下的 organization ID 和 member ID。
+
+project secret 只能存放在 secret manager、环境变量或其他私有配置机制中，不要提交真实 secret 到 Git。
+
+### 2. 配置 Connected App
+
+在 Stytch 中为 ChatGPT 或目标 MCP 客户端创建 Connected App。
+
+需要配置：
+
+- Redirect URI：MCP 客户端或 ChatGPT connector setup 要求的 redirect URI。
+- Allowed scopes：加入客户端会请求的 FNS MCP scopes，例如 `notes:read`、`notes:write`、`files:read`、`files:write`、`vaults:read`。
+- Authorization entry point：指向 FNS authorize page，例如 `https://fns.example.com/oauth/authorize`。
+
+authorize page 会解析 `client_id`、`redirect_uri`、`response_type`、`scope`、`state`、`nonce`、`code_challenge`、`code_challenge_method` 等 OAuth 参数，然后调用已认证的 FNS Stytch bridge endpoints。
+
+### 可选：通过 Stytch MCP 配置
+
+Stytch 也提供自己的 MCP server：
+
+```text
+https://mcp.stytch.dev/mcp
+```
+
+Stytch MCP 可以在支持 MCP 的开发环境中用自然语言管理 Stytch project 配置，而不必全部通过 Dashboard 点击完成。它仍然需要先完成 Stytch workspace 的 OAuth 授权，才能读取或修改 workspace 资源。
+
+可用时，可以用 Stytch MCP 检查或配置 project 类型、Connected App client、redirect URIs、public tokens、SDK settings，以及 Connected Apps 需要的 workspace-level settings。
+
+即使使用 Stytch MCP，FNS 的 `config.yaml` 仍然是 FNS 部署配置的来源。Stytch MCP 只配置 Stytch，不会更新 FNS 服务配置。
+
+### 3. 将 Stytch 值写入 FNS
+
+B2B 示例：
+
+```yaml
+oauth:
+  stytch:
+    enabled: true
+    kind: "b2b"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    organization-id: "organization-live-..."
+    member-id: "member-live-..."
+```
+
+Consumer 示例：
+
+```yaml
+oauth:
+  stytch:
+    enabled: true
+    kind: "consumer"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    user-id-prefix: "fns:"
+```
+
+Consumer mode 会优先使用 `stytch.user-id`。如果没有配置，则发送 `stytch.user-id-prefix + <FNS UID>` 给 Stytch。
+
+## 启用步骤
+
+1. 通过 HTTPS 部署 FNS，确保公网 base URL 稳定，例如 `https://fns.example.com`。
+2. 设置 `server.ext-api-url` 为公网 origin。
+3. 配置 Stytch Connected App，并收集 domain、project ID、secret，以及 B2B 场景下的 organization/member IDs。
+4. 添加 `oauth` 配置块。`resource` 设置为 `https://fns.example.com/api/mcp`，`issuer`、`jwks-url` 和 `authorization-servers` 设置为 Stytch customer domain 及其 JWKS URL。
+5. 安全存储 Stytch secret。使用你的常规 secret 管理方式，或使用未提交的本地配置文件，不要提交真实 Stytch secret。
+6. 重启 FNS 服务。
+7. 验证 protected resource metadata：
+
+   ```bash
+   curl -sS https://fns.example.com/.well-known/oauth-protected-resource/api/mcp
+   ```
+
+8. 验证 MCP challenge：
+
+   ```bash
+   curl -i https://fns.example.com/api/mcp
+   ```
+
+   期望返回 `401`，并包含指向 metadata 的 `WWW-Authenticate` header。
+
+9. 在 ChatGPT 或其他支持 OAuth 的 MCP 客户端中添加 MCP server：`https://fns.example.com/api/mcp`。
+10. 授权过程中，如果 authorize page 要求登录 FNS，请先登录 FNS，因为 bridge endpoints 使用现有 FNS WebGUI token 保护。
+11. consent 完成后，确认 MCP 客户端可以列出并调用 tools。
+
+## Static token 兼容
+
+如果 `allow-static-fns-token: true`，现有 MCP 客户端仍可继续使用 FNS static token：
+
+```http
+Authorization: Bearer <fns-token>
+```
+
+如果需要 OAuth-only MCP access：
+
+```yaml
+oauth:
+  allow-static-fns-token: false
+```
+
+## Troubleshooting
+
+### ChatGPT 提示 MCP server does not implement OAuth
+
+检查：
+
+- `oauth.enabled` 为 true。
+- `https://fns.example.com/.well-known/oauth-protected-resource/api/mcp` 返回 HTTP 200。
+- `https://fns.example.com/api/mcp` 返回 `401`，并且 `WWW-Authenticate` header 包含 `resource_metadata`。
+- `oauth.resource` 与公开 MCP endpoint URL 完全一致。
+- ingress 暴露了 `/.well-known/oauth-protected-resource/api/mcp`。
+
+### Metadata 缺少 `authorization_servers`
+
+检查 `oauth.authorization-servers`。它必须至少包含一个授权服务器 origin。
+
+### Token verification 返回 `invalid_token`
+
+检查 token 的 `iss` claim、`oauth.jwks-url` 可达性、JWKS 中是否存在签名 key、token 是否过期，以及 `oauth.audience` 或 `oauth.resource` 是否匹配 token audience/resource。
+
+### Token verification 返回 `insufficient_scope`
+
+检查 token 是否包含 `oauth.required-scopes` 中列出的 scopes、Stytch Connected App 是否允许签发请求的 FNS scopes，以及 `default-fns-scope` 是否符合预期。
+
+### WebGUI 没有 OIDC 登录按钮
+
+这是预期行为。当前实现不提供 WebGUI OIDC SSO，只保护 MCP 路由，并为 MCP 客户端提供 OAuth authorization bridge。
+
+### `/api/user/auth/callback` 返回 404
+
+这是预期行为。该 endpoint 没有实现。
+
+### Stytch authorize start 或 submit 失败
+
+检查 `oauth.stytch.enabled`、`oauth.stytch.domain`、`project-id`、`secret`、B2B 的 `organization-id` 和 `member-id`、Connected App 的 `client_id`/`redirect_uri`/scopes，以及用户是否已在 `/oauth/authorize` 前登录 FNS。

--- a/docs/runbook/mcp-oauth-stytch.zh-TW.md
+++ b/docs/runbook/mcp-oauth-stytch.zh-TW.md
@@ -1,0 +1,314 @@
+# MCP OAuth 與 Stytch 運行手冊
+
+語言：[English](mcp-oauth-stytch.md) | [简体中文](mcp-oauth-stytch.zh-CN.md) | [繁體中文](mcp-oauth-stytch.zh-TW.md)
+
+用途：將 Fast Note Sync Service 設定為受 OAuth 保護的 MCP 資源，供 ChatGPT 與其他支援 OAuth 的 MCP 用戶端存取。
+
+當你需要啟用 MCP OAuth、把 Stytch 設定為授權伺服器、設定 FNS 部署，或排查 ChatGPT connector 授權問題時，閱讀本文。
+
+本文不涵蓋 WebGUI OIDC SSO 登入。當前實作不會在 WebGUI 中新增「使用 OIDC 登入」、「使用 Stytch 登入」或「使用 Casdoor 登入」按鈕，也沒有實作 `/api/user/auth/callback` 這類 WebGUI callback route。
+
+## 當前實作目標
+
+當前 OAuth 實作的目標是 MCP 存取控制。
+
+當 `oauth.enabled` 為 `true` 時，`/api/mcp` 與 `/api/mcp/sse` 會成為支援 OAuth 的受保護資源：
+
+1. 未認證的 MCP request 會收到 `401 Unauthorized`，response 中包含 `WWW-Authenticate` header。
+2. 這個 challenge 會指向 protected resource metadata，通常是 `/.well-known/oauth-protected-resource/api/mcp`。
+3. metadata 會宣告目前 FNS 部署是受保護資源，並列出設定的授權伺服器。
+4. ChatGPT 或其他支援 OAuth 的 MCP 用戶端會到該授權伺服器完成 OAuth。
+5. 用戶端後續請求 MCP 時會帶上 `Authorization: Bearer <access-token>`。
+6. FNS 使用設定中的 issuer、JWKS URL、audience/resource 與 scopes 本地驗證 bearer JWT。
+7. FNS 將驗證後的 JWT subject 映射到 FNS 使用者，並將 OAuth scopes 映射為 FNS MCP 權限。
+
+這符合 ChatGPT Apps SDK 的認證模型：OAuth 完成後，ChatGPT 會把 access token 附加到 MCP requests；MCP server 仍然負責 token 簽名驗證、issuer/audience 檢查、過期時間檢查與 scope enforcement。
+
+參考資料：
+
+- OpenAI Apps SDK authentication: <https://developers.openai.com/apps-sdk/build/auth#implementing-token-verification>
+- OpenAI Apps SDK MCP overview: <https://developers.openai.com/apps-sdk/concepts/mcp-server#why-apps-sdk-standardises-on-mcp>
+- Stytch MCP Server: <https://stytch.com/docs/resources/workspace-management/stytch-mcp-server>
+- Stytch custom Connected Apps flow: <https://stytch.com/docs/connected-apps/build-custom-flow/getting-started-api>
+- Stytch B2B Start OAuth Authorization API: <https://stytch.com/docs/api-reference/b2b/api/connected-apps/consent-management/start-oauth-authorization>
+
+## 當前不支援什麼
+
+這不是 WebGUI OIDC SSO。
+
+當前實作不支援：
+
+- 給 WebGUI 新增 Casdoor 等通用 OIDC provider 的登入按鈕。
+- WebGUI OIDC callback endpoint，例如 `/api/user/auth/callback`。
+- 透過外部 OIDC 登入自動建立或映射 WebGUI 使用者。
+- 用 Stytch、Casdoor、Pocket ID 或其他 OIDC provider 取代 `/api/user/login`。
+
+`oauth` 設定區塊用於驗證 MCP request 中的 bearer token，不會改變 WebGUI 登入行為。
+
+## 相關程式碼路徑
+
+- `internal/config/oauth.go`：設定結構、預設值、校驗邏輯與 protected resource metadata。
+- `internal/routers/router_oauth_metadata.go`：OAuth protected resource metadata routes。
+- `internal/routers/router_mcp.go`：受 OAuth-aware middleware 保護的 MCP routes。
+- `internal/middleware/mcp_oauth.go`：MCP static token 與 OAuth 混合認證。
+- `internal/oauth/verifier.go`：使用 issuer、audience、JWKS、過期時間與 scopes 驗證 JWT。
+- `internal/oauth/subject_mapper.go`：JWT subject 到 FNS UID 的映射。
+- `internal/oauth/scope_mapper.go`：OAuth scope 到 FNS MCP 權限的映射。
+- `internal/oauth/stytch_client.go`：Stytch authorize start/submit API client。
+- `internal/routers/api_router/handler_stytch_oauth.go`：將 authorize page 橋接到 Stytch 的已認證 FNS API。
+- `frontend/oauth-authorize.html`：由 WebGUI 建置出的 OAuth authorize page。
+
+## 對外端點
+
+啟用 OAuth 後，部署必須透過 HTTPS 暴露這些端點：
+
+| Endpoint | 用途 |
+| --- | --- |
+| `/api/mcp` | Streamable HTTP MCP endpoint。 |
+| `/api/mcp/sse` | 舊版 SSE MCP endpoint。 |
+| `/.well-known/oauth-protected-resource/api/mcp` | `/api/mcp` 的 protected resource metadata。 |
+| `/.well-known/oauth-protected-resource` | 通用 protected resource metadata endpoint。 |
+| `/oauth/authorize` | Stytch Connected App 授權流程使用的瀏覽器頁面。 |
+| `/api/oauth/stytch/authorize/start` | 已認證 FNS API，會呼叫 Stytch authorize start。 |
+| `/api/oauth/stytch/authorize/submit` | 已認證 FNS API，會呼叫 Stytch authorize submit。 |
+
+兩個 `/api/oauth/stytch/*` endpoint 都需要已有的 FNS WebGUI login token。如果瀏覽器中沒有 `localStorage.token`，authorize page 會先要求使用者登入 FNS。
+
+## 設定參考
+
+在 `config.yaml` 中新增或更新 `oauth` 設定區塊：
+
+```yaml
+oauth:
+  enabled: true
+  resource: "https://fns.example.com/api/mcp"
+  authorization-servers:
+    - "https://example.customers.stytch.com"
+  jwks-url: "https://example.customers.stytch.com/.well-known/jwks.json"
+  issuer: "https://example.customers.stytch.com"
+  audience: []
+  scopes-supported:
+    - notes:read
+    - notes:write
+    - files:read
+    - files:write
+    - vaults:read
+  required-scopes:
+    - notes:read
+    - files:read
+    - vaults:read
+  resource-name: "Fast Note Sync MCP"
+  allow-static-fns-token: true
+  default-client: "ChatGPT"
+  default-client-name: "ChatGPT"
+  default-client-version: ""
+  default-vault-name: "main"
+  default-fns-scope: ""
+  subject-mapping:
+    mode: "email_or_fixed_uid"
+    claim: "email"
+    fixed-uid: 1
+  stytch:
+    enabled: true
+    kind: "b2b"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    organization-id: "organization-live-..."
+    member-id: "member-live-..."
+```
+
+### 核心 OAuth 欄位
+
+| 欄位 | 啟用後是否必填 | 說明 |
+| --- | --- | --- |
+| `enabled` | 是 | 啟用 MCP OAuth-aware authentication 與 protected resource metadata。 |
+| `resource` | 是 | 受保護資源識別。ChatGPT MCP 情境下使用公開 MCP endpoint，例如 `https://fns.example.com/api/mcp`。 |
+| `authorization-servers` | 是 | 暴露給 MCP 用戶端的授權伺服器 origin。Stytch 情境下使用 Stytch customer domain origin。 |
+| `jwks-url` | 是 | FNS 用來驗證 JWT 簽名的 JWKS endpoint。 |
+| `issuer` | 是 | 預期的 JWT issuer，必須符合 token 的 `iss` claim。 |
+| `audience` | 否 | 可選的 JWT audience 清單。為空時，FNS 使用 `resource` 作為預期 audience。 |
+| `scopes-supported` | 否 | 寫入 protected resource metadata 的 scopes。預設是 FNS MCP 標準 scopes。 |
+| `required-scopes` | 否 | 每個 OAuth token 必須包含的 scopes。預設是 `notes:read`、`files:read` 與 `vaults:read`。 |
+| `resource-name` | 否 | metadata 中展示的人類可讀資源名。 |
+| `allow-static-fns-token` | 否 | 啟用 OAuth 時是否繼續允許原有 FNS static token MCP 用戶端存取。預設 true。 |
+
+只有在授權伺服器或用戶端無法簽發 FNS 自訂 scopes，且你明確希望依賴 FNS permission mapping 或部署層控制時，才使用 `required-scopes: []`。更嚴格的公開部署應保留明確 required scopes。
+
+### FNS 身分與權限映射
+
+| 欄位 | 說明 |
+| --- | --- |
+| `subject-mapping.mode` | `email`、`fixed_uid` 或 `email_or_fixed_uid`。 |
+| `subject-mapping.claim` | 透過信箱匹配 FNS 使用者時讀取的 JWT claim，預設 `email`。 |
+| `subject-mapping.fixed-uid` | `fixed_uid` 模式使用的 FNS UID，或 `email_or_fixed_uid` 模式的 fallback UID。 |
+| `default-fns-scope` | 如果設定，則跳過 OAuth scope mapping，直接給已驗證 OAuth request 授予該 FNS scope。 |
+| `default-client`, `default-client-name`, `default-client-version` | request 或 token 未提供用戶端資訊時使用的預設 MCP client headers。 |
+| `default-vault-name` | MCP 操作未提供 vault 參數時使用的預設筆記庫名稱。 |
+
+單使用者部署最簡單的設定是 `fixed_uid`：
+
+```yaml
+subject-mapping:
+  mode: fixed_uid
+  fixed-uid: 1
+```
+
+多使用者部署建議使用 email mapping：
+
+```yaml
+subject-mapping:
+  mode: email
+  claim: email
+```
+
+被驗證的 access token 中必須存在對應 email claim，且 FNS 中必須已經存在該使用者。
+
+## Stytch 設定
+
+使用 Stytch Connected Apps 作為授權伺服器。FNS server 本身不是完整 OAuth authorization server；它是 MCP protected resource，並使用 Stytch 簽發 token。
+
+### 1. 建立或選擇 Stytch project
+
+可選類型：
+
+- B2B project：建議用於受控的 organization/member 存取。
+- Consumer project：適用於不需要 organization/member 識別的使用者存取。
+
+記錄這些值：Stytch project ID、Stytch project secret、Stytch customer domain，以及 B2B 情境下的 organization ID 與 member ID。
+
+project secret 只能存放在 secret manager、環境變數或其他私有設定機制中，不要提交真實 secret 到 Git。
+
+### 2. 設定 Connected App
+
+在 Stytch 中為 ChatGPT 或目標 MCP 用戶端建立 Connected App。
+
+需要設定：
+
+- Redirect URI：MCP 用戶端或 ChatGPT connector setup 要求的 redirect URI。
+- Allowed scopes：加入用戶端會請求的 FNS MCP scopes，例如 `notes:read`、`notes:write`、`files:read`、`files:write`、`vaults:read`。
+- Authorization entry point：指向 FNS authorize page，例如 `https://fns.example.com/oauth/authorize`。
+
+authorize page 會解析 `client_id`、`redirect_uri`、`response_type`、`scope`、`state`、`nonce`、`code_challenge`、`code_challenge_method` 等 OAuth 參數，然後呼叫已認證的 FNS Stytch bridge endpoints。
+
+### 可選：透過 Stytch MCP 設定
+
+Stytch 也提供自己的 MCP server：
+
+```text
+https://mcp.stytch.dev/mcp
+```
+
+Stytch MCP 可以在支援 MCP 的開發環境中用自然語言管理 Stytch project 設定，而不必全部透過 Dashboard 點擊完成。它仍然需要先完成 Stytch workspace 的 OAuth 授權，才能讀取或修改 workspace 資源。
+
+可用時，可以用 Stytch MCP 檢查或設定 project 類型、Connected App client、redirect URIs、public tokens、SDK settings，以及 Connected Apps 需要的 workspace-level settings。
+
+即使使用 Stytch MCP，FNS 的 `config.yaml` 仍然是 FNS 部署設定的來源。Stytch MCP 只設定 Stytch，不會更新 FNS 服務設定。
+
+### 3. 將 Stytch 值寫入 FNS
+
+B2B 範例：
+
+```yaml
+oauth:
+  stytch:
+    enabled: true
+    kind: "b2b"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    organization-id: "organization-live-..."
+    member-id: "member-live-..."
+```
+
+Consumer 範例：
+
+```yaml
+oauth:
+  stytch:
+    enabled: true
+    kind: "consumer"
+    domain: "https://example.customers.stytch.com"
+    project-id: "project-live-..."
+    secret: "${FNS_STYTCH_SECRET}"
+    user-id-prefix: "fns:"
+```
+
+Consumer mode 會優先使用 `stytch.user-id`。如果沒有設定，則傳送 `stytch.user-id-prefix + <FNS UID>` 給 Stytch。
+
+## 啟用步驟
+
+1. 透過 HTTPS 部署 FNS，確保公開 base URL 穩定，例如 `https://fns.example.com`。
+2. 設定 `server.ext-api-url` 為公開 origin。
+3. 設定 Stytch Connected App，並收集 domain、project ID、secret，以及 B2B 情境下的 organization/member IDs。
+4. 新增 `oauth` 設定區塊。`resource` 設定為 `https://fns.example.com/api/mcp`，`issuer`、`jwks-url` 與 `authorization-servers` 設定為 Stytch customer domain 及其 JWKS URL。
+5. 安全儲存 Stytch secret。使用你的常規 secret 管理方式，或使用未提交的本地設定檔，不要提交真實 Stytch secret。
+6. 重啟 FNS 服務。
+7. 驗證 protected resource metadata：
+
+   ```bash
+   curl -sS https://fns.example.com/.well-known/oauth-protected-resource/api/mcp
+   ```
+
+8. 驗證 MCP challenge：
+
+   ```bash
+   curl -i https://fns.example.com/api/mcp
+   ```
+
+   預期返回 `401`，並包含指向 metadata 的 `WWW-Authenticate` header。
+
+9. 在 ChatGPT 或其他支援 OAuth 的 MCP 用戶端中新增 MCP server：`https://fns.example.com/api/mcp`。
+10. 授權過程中，如果 authorize page 要求登入 FNS，請先登入 FNS，因為 bridge endpoints 使用現有 FNS WebGUI token 保護。
+11. consent 完成後，確認 MCP 用戶端可以列出並呼叫 tools。
+
+## Static token 相容
+
+如果 `allow-static-fns-token: true`，現有 MCP 用戶端仍可繼續使用 FNS static token：
+
+```http
+Authorization: Bearer <fns-token>
+```
+
+如果需要 OAuth-only MCP access：
+
+```yaml
+oauth:
+  allow-static-fns-token: false
+```
+
+## Troubleshooting
+
+### ChatGPT 提示 MCP server does not implement OAuth
+
+檢查：
+
+- `oauth.enabled` 為 true。
+- `https://fns.example.com/.well-known/oauth-protected-resource/api/mcp` 返回 HTTP 200。
+- `https://fns.example.com/api/mcp` 返回 `401`，且 `WWW-Authenticate` header 包含 `resource_metadata`。
+- `oauth.resource` 與公開 MCP endpoint URL 完全一致。
+- ingress 暴露了 `/.well-known/oauth-protected-resource/api/mcp`。
+
+### Metadata 缺少 `authorization_servers`
+
+檢查 `oauth.authorization-servers`。它必須至少包含一個授權伺服器 origin。
+
+### Token verification 返回 `invalid_token`
+
+檢查 token 的 `iss` claim、`oauth.jwks-url` 可達性、JWKS 中是否存在簽名 key、token 是否過期，以及 `oauth.audience` 或 `oauth.resource` 是否符合 token audience/resource。
+
+### Token verification 返回 `insufficient_scope`
+
+檢查 token 是否包含 `oauth.required-scopes` 中列出的 scopes、Stytch Connected App 是否允許簽發請求的 FNS scopes，以及 `default-fns-scope` 是否符合預期。
+
+### WebGUI 沒有 OIDC 登入按鈕
+
+這是預期行為。當前實作不提供 WebGUI OIDC SSO，只保護 MCP routes，並為 MCP 用戶端提供 OAuth authorization bridge。
+
+### `/api/user/auth/callback` 返回 404
+
+這是預期行為。該 endpoint 沒有實作。
+
+### Stytch authorize start 或 submit 失敗
+
+檢查 `oauth.stytch.enabled`、`oauth.stytch.domain`、`project-id`、`secret`、B2B 的 `organization-id` 和 `member-id`、Connected App 的 `client_id`/`redirect_uri`/scopes，以及使用者是否已在 `/oauth/authorize` 前登入 FNS。


### PR DESCRIPTION
## Summary
- Add English, Simplified Chinese, and Traditional Chinese runbooks for OAuth-protected MCP deployments with Stytch.
- Document the current implementation scope, config fields, Stytch setup, verification steps, and troubleshooting.
- Link the runbooks from the English, zh-CN, and zh-TW README MCP sections.

## Notes
- This documents MCP OAuth authorization for ChatGPT/OAuth-capable MCP clients.
- It explicitly documents that the current implementation does not provide WebGUI OIDC SSO login or `/api/user/auth/callback`.
- Stytch tenant values and secrets are represented with placeholders only.

## Validation
- `git diff --check`
- Secret/tenant grep check for known real deployment values