### PR TITLE
Add MCP recursive folder delete

### DIFF
--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -75,7 +75,7 @@ func initServices(cfg *AppConfig, infra *Infra, repos *Repositories, logger *zap
 	// SyncLogService 必须最先初始化，因为其他服务依赖它
 	s.SyncLogService = service.NewSyncLogService(repos.SyncLogRepo)
 
-	s.FolderService = service.NewFolderService(repos.FolderRepo, repos.NoteRepo, repos.FileRepo, s.VaultService, s.BackupService, s.SyncLogService, infra.workerPool)
+	s.FolderService = service.NewFolderService(repos.FolderRepo, repos.NoteRepo, repos.FileRepo, s.VaultService, s.BackupService, s.GitSyncService, s.SyncLogService, infra.workerPool)
 	s.NoteService = service.NewNoteService(repos.UserRepo, repos.NoteRepo, repos.NoteLinkRepo, repos.FileRepo, repos.ShareRepo, s.VaultService, s.FolderService, s.BackupService, s.GitSyncService, s.SyncLogService, svcConfig)
 	s.TokenService = service.NewTokenService(repos.AuthTokenRepo, repos.AuthTokenLogRepo, infra.TokenManager, logger, svcConfig.Token)
 	s.UserService = service.NewUserService(repos.UserRepo, infra.TokenManager, s.TokenService, logger, svcConfig)

--- a/internal/dao/file_repository.go
+++ b/internal/dao/file_repository.go
@@ -712,6 +712,9 @@ func (r *fileRepository) ListByPathPrefix(ctx context.Context, pathPrefix string
 	}
 	var res []*domain.File
 	for _, m := range ms {
+		if !isPathWithinPrefix(m.Path, pathPrefix) {
+			continue
+		}
 		res = append(res, r.toDomain(m, uid))
 	}
 	return res, nil

--- a/internal/dao/folder_repository.go
+++ b/internal/dao/folder_repository.go
@@ -161,6 +161,9 @@ func (r *folderRepository) ListByPathPrefix(ctx context.Context, pathPrefix stri
 	}
 	var res []*domain.Folder
 	for _, m := range ms {
+		if !isPathWithinPrefix(m.Path, pathPrefix) {
+			continue
+		}
 		res = append(res, r.modelToDomain(m))
 	}
 	return res, nil

--- a/internal/dao/note_repository.go
+++ b/internal/dao/note_repository.go
@@ -695,6 +695,9 @@ func (r *noteRepository) ListByPathPrefix(ctx context.Context, pathPrefix string
 	}
 	var res []*domain.Note
 	for _, m := range ms {
+		if !isPathWithinPrefix(m.Path, pathPrefix) {
+			continue
+		}
 		note, err := r.toDomain(m, uid)
 		if err != nil {
 			return nil, err

--- a/internal/dao/path_prefix.go
+++ b/internal/dao/path_prefix.go
@@ -1,0 +1,12 @@
+package dao
+
+import "strings"
+
+func isPathWithinPrefix(path, prefix string) bool {
+	path = strings.Trim(path, "/")
+	prefix = strings.Trim(prefix, "/")
+	if path == "" || prefix == "" || path == prefix {
+		return false
+	}
+	return strings.HasPrefix(path, prefix+"/")
+}

--- a/internal/dao/path_prefix_test.go
+++ b/internal/dao/path_prefix_test.go
@@ -1,0 +1,27 @@
+package dao
+
+import "testing"
+
+func TestIsPathWithinPrefix_UsesPathBoundary(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		prefix string
+		want   bool
+	}{
+		{name: "child", path: "Projects/Archive/todo.md", prefix: "Projects", want: true},
+		{name: "exact path is not child", path: "Projects", prefix: "Projects", want: false},
+		{name: "sibling prefix", path: "Projects-old/todo.md", prefix: "Projects", want: false},
+		{name: "underscore is literal", path: "fooXbar/todo.md", prefix: "foo_bar", want: false},
+		{name: "percent is literal", path: "fooooo/bar/todo.md", prefix: "foo%/bar", want: false},
+		{name: "trim slashes", path: "/Projects/Archive/todo.md/", prefix: "/Projects/", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPathWithinPrefix(tt.path, tt.prefix); got != tt.want {
+				t.Fatalf("isPathWithinPrefix(%q, %q) = %v, want %v", tt.path, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/domain_folder.go
+++ b/internal/domain/domain_folder.go
@@ -61,6 +61,9 @@ type FolderRepository interface {
 	// ListByUpdatedTimestamp 根据更新时间戳获取文件夹列表
 	ListByUpdatedTimestamp(ctx context.Context, timestamp, vaultID, uid int64) ([]*Folder, error)
 
+	// ListByPathPrefix 获取指定路径下的子文件夹
+	ListByPathPrefix(ctx context.Context, pathPrefix string, vaultID, uid int64) ([]*Folder, error)
+
 	// List 获取指定仓库下的所有文件夹
 	List(ctx context.Context, vaultID int64, uid int64) ([]*Folder, error)
 	// ListAll 获取该用户所有的文件夹

--- a/internal/domain/mocks/mock_folder_repository.go
+++ b/internal/domain/mocks/mock_folder_repository.go
@@ -76,6 +76,14 @@ func (m *MockFolderRepository) ListByUpdatedTimestamp(ctx context.Context, times
 	return args.Get(0).([]*domain.Folder), args.Error(1)
 }
 
+func (m *MockFolderRepository) ListByPathPrefix(ctx context.Context, pathPrefix string, vaultID, uid int64) ([]*domain.Folder, error) {
+	args := m.Called(ctx, pathPrefix, vaultID, uid)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Folder), args.Error(1)
+}
+
 func (m *MockFolderRepository) List(ctx context.Context, vaultID int64, uid int64) ([]*domain.Folder, error) {
 	args := m.Called(ctx, vaultID, uid)
 	if args.Get(0) == nil {

--- a/internal/routers/mcp_router/folder_tools.go
+++ b/internal/routers/mcp_router/folder_tools.go
@@ -1,0 +1,67 @@
+package mcp_router
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/haierkeys/fast-note-sync-service/internal/app"
+	"github.com/haierkeys/fast-note-sync-service/internal/dto"
+	pkgapp "github.com/haierkeys/fast-note-sync-service/pkg/app"
+	"github.com/haierkeys/fast-note-sync-service/pkg/code"
+	"github.com/haierkeys/fast-note-sync-service/pkg/util"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpsrv "github.com/mark3labs/mcp-go/server"
+)
+
+func registerFolderTools(srv *mcpsrv.MCPServer, appContainer *app.App, wss *pkgapp.WebsocketServer) {
+	folderSvc := appContainer.FolderService
+	cfg := appContainer.Config()
+
+	toolDeleteFolder := mcp.NewTool("folder_delete",
+		mcp.WithDescription("Recursively delete a folder in a vault. Requires the exact vault-relative folder path. The root folder cannot be deleted."),
+		mcp.WithOutputSchema[mcpFolderMutationOutput](),
+		mcp.WithString("vault", mcp.Description("Vault name. Omitting this or providing 'default' will use the client-configured default vault.")),
+		mcp.WithString("path", mcp.Required(), mcp.Description("Exact vault-relative folder path to delete recursively.")),
+	)
+	srv.AddTool(writeMCPTool(toolDeleteFolder, cfg, true, "notes:write"), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if err := checkPermission(ctx, "note_w"); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		uid := getUIDFromContext(ctx)
+		args := getArgs(req)
+		vault, _ := args["vault"].(string)
+		if vault == "" || strings.EqualFold(vault, "default") {
+			vault = getDefaultVaultName(ctx, appContainer)
+		}
+		if err := checkVaultAccess(ctx, vault); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		path, _ := args["path"].(string)
+		path = strings.Trim(path, "/")
+		folder, err := folderSvc.WithClient(getClientInfoFromContext(ctx)).DeleteTree(ctx, uid, &dto.FolderDeleteRequest{
+			Vault:    vault,
+			Path:     path,
+			PathHash: util.EncodeHash32(path),
+		})
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if wss != nil {
+			wss.BroadcastToUser(uid, code.Success.WithData(dto.FolderSyncDeleteMessage{
+				Path:             folder.Path,
+				PathHash:         folder.PathHash,
+				Ctime:            folder.Ctime,
+				Mtime:            folder.Mtime,
+				UpdatedTimestamp: folder.UpdatedTimestamp,
+			}).WithVault(vault), "FolderSyncDelete")
+		}
+		fallback := fmt.Sprintf("Deleted folder recursively: %s", folder.Path)
+		return mcp.NewToolResultStructured(mcpFolderMutationOutput{
+			Vault:     vault,
+			Operation: "delete",
+			Folder:    folder,
+		}, fallback), nil
+	})
+}

--- a/internal/routers/mcp_router/server.go
+++ b/internal/routers/mcp_router/server.go
@@ -100,6 +100,9 @@ func NewMCPServer(appContainer *app.App, wss *pkgapp.WebsocketServer) *mcpsrv.MC
 	// File Tools
 	registerFileTools(srv, appContainer, wss)
 
+	// Folder Tools
+	registerFolderTools(srv, appContainer, wss)
+
 	// Vault Tools
 	registerVaultTools(srv, appContainer)
 

--- a/internal/routers/mcp_router/tool_metadata_test.go
+++ b/internal/routers/mcp_router/tool_metadata_test.go
@@ -103,7 +103,7 @@ func TestToolMetadataMarshalIncludesSecuritySchemesAndAnnotations(t *testing.T) 
 }
 
 func TestMCPToolDefinitionsDeclareOutputSchemasAndMetadata(t *testing.T) {
-	files := []string{"note_tools.go", "file_tools.go", "vault_tools.go"}
+	files := []string{"note_tools.go", "file_tools.go", "folder_tools.go", "vault_tools.go"}
 	toolDefRE := regexp.MustCompile(`(\w+)\s*:=\s*mcp\.NewTool\("([^"]+)"`)
 	addToolRE := regexp.MustCompile(`srv\.AddTool\(([^,]+),`)
 

--- a/internal/routers/mcp_router/tool_outputs.go
+++ b/internal/routers/mcp_router/tool_outputs.go
@@ -75,6 +75,12 @@ type mcpFileWriteOutput struct {
 	File  *dto.McpFileDTO `json:"file"`
 }
 
+type mcpFolderMutationOutput struct {
+	Vault     string         `json:"vault"`
+	Operation string         `json:"operation"`
+	Folder    *dto.FolderDTO `json:"folder,omitempty"`
+}
+
 type mcpVaultListOutput struct {
 	Count  int             `json:"count"`
 	Vaults []*dto.VaultDTO `json:"vaults"`

--- a/internal/service/file_service.go
+++ b/internal/service/file_service.go
@@ -887,6 +887,14 @@ func (s *fileService) Rename(ctx context.Context, uid int64, params *dto.FileRen
 
 		// 修正目录FID
 		go s.folderService.SyncResourceFID(context.Background(), uid, vaultID, nil, []int64{newFileCreated.ID})
+		if err := s.folderService.CleanupEmptyAncestors(ctx, uid, vaultID, oldPath); err != nil {
+			zap.L().Warn("fileService.Rename: cleanup empty ancestor folders failed",
+				zap.Int64("uid", uid),
+				zap.Int64("vaultID", vaultID),
+				zap.String("oldPath", oldPath),
+				zap.Error(err),
+			)
+		}
 
 		if s.backupService != nil {
 			go s.backupService.NotifyUpdated(uid)

--- a/internal/service/folder_service.go
+++ b/internal/service/folder_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -25,10 +26,12 @@ type FolderService interface {
 	ListByUpdatedTimestamp(ctx context.Context, uid int64, vault string, lastTime int64) ([]*dto.FolderDTO, error)
 	UpdateOrCreate(ctx context.Context, uid int64, params *dto.FolderCreateRequest) (*dto.FolderDTO, error)
 	Delete(ctx context.Context, uid int64, params *dto.FolderDeleteRequest) (*dto.FolderDTO, error)
+	DeleteTree(ctx context.Context, uid int64, params *dto.FolderDeleteRequest) (*dto.FolderDTO, error)
 	Rename(ctx context.Context, uid int64, params *dto.FolderRenameRequest) (*dto.FolderDTO, *dto.FolderDTO, error)
 	ListNotes(ctx context.Context, uid int64, params *dto.FolderContentRequest, pager *app.Pager) ([]*dto.NoteNoContentDTO, int, error)
 	ListFiles(ctx context.Context, uid int64, params *dto.FolderContentRequest, pager *app.Pager) ([]*dto.FileDTO, int, error)
 	EnsurePathFID(ctx context.Context, uid int64, vaultID int64, path string) (int64, error)
+	CleanupEmptyAncestors(ctx context.Context, uid int64, vaultID int64, resourcePath string) error
 	SyncResourceFID(ctx context.Context, uid int64, vaultID int64, noteIDs []int64, fileIDs []int64) error
 	GetTree(ctx context.Context, uid int64, params *dto.FolderTreeRequest) (*dto.FolderTreeResponse, error)
 	CleanDuplicateFolders(ctx context.Context, uid int64, vaultID int64) error
@@ -42,6 +45,7 @@ type folderService struct {
 	vaultService   VaultService
 	sf             singleflight.Group
 	backupService  BackupService
+	gitSyncService GitSyncService
 	pool           *workerpool.Pool
 	syncLogService SyncLogService
 	clientType     string
@@ -49,13 +53,14 @@ type folderService struct {
 	clientVersion  string
 }
 
-func NewFolderService(folderRepo domain.FolderRepository, noteRepo domain.NoteRepository, fileRepo domain.FileRepository, vaultSvc VaultService, backupSvc BackupService, syncLogSvc SyncLogService, pool *workerpool.Pool) FolderService {
+func NewFolderService(folderRepo domain.FolderRepository, noteRepo domain.NoteRepository, fileRepo domain.FileRepository, vaultSvc VaultService, backupSvc BackupService, gitSyncSvc GitSyncService, syncLogSvc SyncLogService, pool *workerpool.Pool) FolderService {
 	return &folderService{
 		folderRepo:     folderRepo,
 		noteRepo:       noteRepo,
 		fileRepo:       fileRepo,
 		vaultService:   vaultSvc,
 		backupService:  backupSvc,
+		gitSyncService: gitSyncSvc,
 		syncLogService: syncLogSvc,
 		pool:           pool,
 		sf:             singleflight.Group{},
@@ -200,6 +205,98 @@ func (s *folderService) Delete(ctx context.Context, uid int64, params *dto.Folde
 	}
 
 	return s.domainToDTO(f), nil
+}
+
+func (s *folderService) DeleteTree(ctx context.Context, uid int64, params *dto.FolderDeleteRequest) (*dto.FolderDTO, error) {
+	vaultID, err := s.vaultService.MustGetID(ctx, uid, params.Vault)
+	if err != nil {
+		return nil, err
+	}
+
+	params.Path = strings.Trim(params.Path, "/")
+	if params.Path == "" {
+		return nil, code.ErrorInvalidParams.WithDetails("path cannot be empty")
+	}
+	if params.PathHash == "" {
+		params.PathHash = util.EncodeHash32(params.Path)
+	}
+
+	rootFolders, err := s.folderRepo.GetAllByPathHash(ctx, params.PathHash, vaultID, uid)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, code.ErrorFolderNotFound
+		}
+		return nil, code.ErrorFolderGetFailed.WithDetails(err.Error())
+	}
+	if len(rootFolders) == 0 {
+		return nil, code.ErrorFolderNotFound
+	}
+	root := rootFolders[0]
+
+	childFolders, err := s.folderRepo.ListByPathPrefix(ctx, params.Path, vaultID, uid)
+	if err != nil {
+		return nil, code.ErrorFolderListFailed.WithDetails(err.Error())
+	}
+	notes, err := s.noteRepo.ListByPathPrefix(ctx, params.Path, vaultID, uid)
+	if err != nil {
+		return nil, code.ErrorNoteListFailed.WithDetails(err.Error())
+	}
+	files, err := s.fileRepo.ListByPathPrefix(ctx, params.Path, vaultID, uid)
+	if err != nil {
+		return nil, code.ErrorFileListFailed.WithDetails(err.Error())
+	}
+
+	now := timex.Now().UnixMilli()
+	for _, n := range notes {
+		n.Action = domain.NoteActionDelete
+		n.Rename = 0
+		n.UpdatedTimestamp = now
+		if err := s.noteRepo.UpdateDelete(ctx, n, uid); err != nil {
+			return nil, code.ErrorDBQuery.WithDetails(err.Error())
+		}
+		if s.syncLogService != nil {
+			s.syncLogService.Log(uid, vaultID, domain.SyncLogTypeNote, domain.SyncLogActionSoftDelete, "", n.Path, n.PathHash, s.clientType, s.clientName, s.clientVersion, n.Size)
+		}
+	}
+
+	for _, f := range files {
+		f.Action = domain.FileActionDelete
+		f.Rename = 0
+		f.UpdatedTimestamp = now
+		if _, err := s.fileRepo.Update(ctx, f, uid); err != nil {
+			return nil, code.ErrorDBQuery.WithDetails(err.Error())
+		}
+		if s.syncLogService != nil {
+			s.syncLogService.Log(uid, vaultID, domain.SyncLogTypeFile, domain.SyncLogActionSoftDelete, "", f.Path, f.PathHash, s.clientType, s.clientName, s.clientVersion, f.Size)
+		}
+	}
+
+	folders := append([]*domain.Folder{}, childFolders...)
+	sort.SliceStable(folders, func(i, j int) bool {
+		return strings.Count(folders[i].Path, "/") > strings.Count(folders[j].Path, "/")
+	})
+	folders = append(folders, rootFolders...)
+	for _, f := range folders {
+		if f.Action == domain.FolderActionDelete {
+			continue
+		}
+		f.Action = domain.FolderActionDelete
+		f.UpdatedTimestamp = now
+		if _, err := s.folderRepo.Update(ctx, f, uid); err != nil {
+			return nil, code.ErrorFolderDeleteFailed.WithDetails(err.Error())
+		}
+		if s.syncLogService != nil {
+			s.syncLogService.Log(uid, vaultID, domain.SyncLogTypeFolder, domain.SyncLogActionDelete, "", f.Path, f.PathHash, s.clientType, s.clientName, s.clientVersion, 0)
+		}
+	}
+
+	if s.backupService != nil {
+		s.backupService.NotifyUpdated(uid)
+	}
+	if s.gitSyncService != nil && (len(notes) > 0 || len(files) > 0) {
+		s.gitSyncService.NotifyUpdated(uid, vaultID)
+	}
+	return s.domainToDTO(root), nil
 }
 
 func (s *folderService) ListByUpdatedTimestamp(ctx context.Context, uid int64, vault string, lastTime int64) ([]*dto.FolderDTO, error) {
@@ -525,6 +622,98 @@ func (s *folderService) EnsurePathFID(ctx context.Context, uid int64, vaultID in
 		currentFID = val.(int64)
 	}
 	return currentFID, nil
+}
+
+func (s *folderService) CleanupEmptyAncestors(ctx context.Context, uid int64, vaultID int64, resourcePath string) error {
+	path := strings.Trim(resourcePath, "/")
+	if path == "" || !strings.Contains(path, "/") {
+		return nil
+	}
+
+	parent := path[:strings.LastIndex(path, "/")]
+	for parent != "" {
+		pathHash := util.EncodeHash32(parent)
+		folders, err := s.folderRepo.GetAllByPathHash(ctx, pathHash, vaultID, uid)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return code.ErrorFolderGetFailed.WithDetails(err.Error())
+		}
+		if len(folders) == 0 {
+			parent = parentPath(parent)
+			continue
+		}
+
+		ids := make([]int64, 0, len(folders))
+		for _, f := range folders {
+			if f.Action != domain.FolderActionDelete {
+				ids = append(ids, f.ID)
+			}
+		}
+		if len(ids) == 0 {
+			parent = parentPath(parent)
+			continue
+		}
+
+		empty, err := s.folderIDsAreEmpty(ctx, uid, vaultID, ids)
+		if err != nil {
+			return err
+		}
+		if !empty {
+			return nil
+		}
+
+		for _, f := range folders {
+			if f.Action == domain.FolderActionDelete {
+				continue
+			}
+			f.Action = domain.FolderActionDelete
+			f.UpdatedTimestamp = timex.Now().UnixMilli()
+			if _, err := s.folderRepo.Update(ctx, f, uid); err != nil {
+				return code.ErrorFolderDeleteFailed.WithDetails(err.Error())
+			}
+			if s.syncLogService != nil {
+				s.syncLogService.Log(uid, vaultID, domain.SyncLogTypeFolder, domain.SyncLogActionDelete, "", f.Path, f.PathHash, s.clientType, s.clientName, s.clientVersion, 0)
+			}
+		}
+
+		parent = parentPath(parent)
+	}
+	return nil
+}
+
+func (s *folderService) folderIDsAreEmpty(ctx context.Context, uid int64, vaultID int64, ids []int64) (bool, error) {
+	for _, id := range ids {
+		children, err := s.folderRepo.GetByFID(ctx, id, vaultID, uid)
+		if err != nil {
+			return false, code.ErrorFolderListFailed.WithDetails(err.Error())
+		}
+		if len(children) > 0 {
+			return false, nil
+		}
+	}
+
+	noteCount, err := s.noteRepo.ListByFIDsCount(ctx, ids, vaultID, uid)
+	if err != nil {
+		return false, code.ErrorNoteListFailed.WithDetails(err.Error())
+	}
+	if noteCount > 0 {
+		return false, nil
+	}
+
+	fileCount, err := s.fileRepo.ListByFIDsCount(ctx, ids, vaultID, uid)
+	if err != nil {
+		return false, code.ErrorFileListFailed.WithDetails(err.Error())
+	}
+	return fileCount == 0, nil
+}
+
+func parentPath(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[:idx]
+	}
+	return ""
 }
 
 // SyncResourceFID syncs FID of resources (called after folder rename/move)

--- a/internal/service/folder_service_test.go
+++ b/internal/service/folder_service_test.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/haierkeys/fast-note-sync-service/internal/domain"
 	domainmocks "github.com/haierkeys/fast-note-sync-service/internal/domain/mocks"
+	"github.com/haierkeys/fast-note-sync-service/internal/dto"
+	"github.com/haierkeys/fast-note-sync-service/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 )
 
 // TestCleanDuplicateFolders uses table-driven tests to verify dedup logic.
@@ -79,4 +82,117 @@ func TestCleanDuplicateFolders(t *testing.T) {
 			mockRepo.AssertExpectations(t)
 		})
 	}
+}
+
+func TestFolderService_DeleteTree_RecursivelySoftDeletesChildrenAndResources(t *testing.T) {
+	ctx := context.Background()
+	uid := int64(1)
+	vaultID := int64(9)
+	vaultName := "vault"
+
+	folderRepo := new(domainmocks.MockFolderRepository)
+	noteRepo := new(domainmocks.MockNoteRepository)
+	fileRepo := new(domainmocks.MockFileRepository)
+	vaultRepo := new(domainmocks.MockVaultRepository)
+
+	root := &domain.Folder{ID: 10, VaultID: vaultID, Action: domain.FolderActionCreate, Path: "Projects", PathHash: util.EncodeHash32("Projects")}
+	child := &domain.Folder{ID: 11, VaultID: vaultID, Action: domain.FolderActionCreate, Path: "Projects/Archive", PathHash: util.EncodeHash32("Projects/Archive")}
+	note := &domain.Note{ID: 20, VaultID: vaultID, Action: domain.NoteActionCreate, Path: "Projects/Archive/todo.md", PathHash: util.EncodeHash32("Projects/Archive/todo.md")}
+	file := &domain.File{ID: 30, VaultID: vaultID, Action: domain.FileActionCreate, Path: "Projects/assets/image.png", PathHash: util.EncodeHash32("Projects/assets/image.png")}
+
+	vaultRepo.On("GetByName", mock.Anything, vaultName, uid).Return(&domain.Vault{ID: vaultID, Name: vaultName}, nil)
+	folderRepo.On("GetAllByPathHash", mock.Anything, root.PathHash, vaultID, uid).Return([]*domain.Folder{root}, nil)
+	folderRepo.On("ListByPathPrefix", mock.Anything, "Projects", vaultID, uid).Return([]*domain.Folder{child}, nil)
+	noteRepo.On("ListByPathPrefix", mock.Anything, "Projects", vaultID, uid).Return([]*domain.Note{note}, nil)
+	fileRepo.On("ListByPathPrefix", mock.Anything, "Projects", vaultID, uid).Return([]*domain.File{file}, nil)
+
+	folderRepo.On("Update", mock.Anything, mock.MatchedBy(func(f *domain.Folder) bool {
+		return f.ID == child.ID && f.Action == domain.FolderActionDelete
+	}), uid).Return(child, nil)
+	folderRepo.On("Update", mock.Anything, mock.MatchedBy(func(f *domain.Folder) bool {
+		return f.ID == root.ID && f.Action == domain.FolderActionDelete
+	}), uid).Return(root, nil)
+	noteRepo.On("UpdateDelete", mock.Anything, mock.MatchedBy(func(n *domain.Note) bool {
+		return n.ID == note.ID && n.Action == domain.NoteActionDelete && n.Rename == 0
+	}), uid).Return(nil)
+	fileRepo.On("Update", mock.Anything, mock.MatchedBy(func(f *domain.File) bool {
+		return f.ID == file.ID && f.Action == domain.FileActionDelete && f.Rename == 0
+	}), uid).Return(file, nil)
+
+	svc := &folderService{
+		folderRepo:   folderRepo,
+		noteRepo:     noteRepo,
+		fileRepo:     fileRepo,
+		vaultService: NewVaultService(vaultRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, zap.NewNop()),
+	}
+
+	got, err := svc.DeleteTree(ctx, uid, &dto.FolderDeleteRequest{Vault: vaultName, Path: "Projects"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Projects", got.Path)
+	folderRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+	fileRepo.AssertExpectations(t)
+	vaultRepo.AssertExpectations(t)
+}
+
+func TestFolderService_DeleteTree_RejectsRootPath(t *testing.T) {
+	ctx := context.Background()
+	uid := int64(1)
+	vaultID := int64(9)
+	vaultName := "vault"
+
+	folderRepo := new(domainmocks.MockFolderRepository)
+	vaultRepo := new(domainmocks.MockVaultRepository)
+	vaultRepo.On("GetByName", mock.Anything, vaultName, uid).Return(&domain.Vault{ID: vaultID, Name: vaultName}, nil)
+
+	svc := &folderService{
+		folderRepo:   folderRepo,
+		vaultService: NewVaultService(vaultRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, zap.NewNop()),
+	}
+
+	got, err := svc.DeleteTree(ctx, uid, &dto.FolderDeleteRequest{Vault: vaultName, Path: "/"})
+
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	folderRepo.AssertNotCalled(t, "GetAllByPathHash", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	vaultRepo.AssertExpectations(t)
+}
+
+func TestFolderService_CleanupEmptyAncestors_StopsAtFirstNonEmptyFolder(t *testing.T) {
+	ctx := context.Background()
+	uid := int64(1)
+	vaultID := int64(9)
+
+	folderRepo := new(domainmocks.MockFolderRepository)
+	noteRepo := new(domainmocks.MockNoteRepository)
+	fileRepo := new(domainmocks.MockFileRepository)
+
+	emptyChild := &domain.Folder{ID: 11, VaultID: vaultID, Action: domain.FolderActionCreate, Path: "Projects/Archive", PathHash: util.EncodeHash32("Projects/Archive")}
+	nonEmptyParent := &domain.Folder{ID: 10, VaultID: vaultID, Action: domain.FolderActionCreate, Path: "Projects", PathHash: util.EncodeHash32("Projects")}
+
+	folderRepo.On("GetAllByPathHash", mock.Anything, emptyChild.PathHash, vaultID, uid).Return([]*domain.Folder{emptyChild}, nil)
+	folderRepo.On("GetByFID", mock.Anything, emptyChild.ID, vaultID, uid).Return([]*domain.Folder{}, nil)
+	noteRepo.On("ListByFIDsCount", mock.Anything, []int64{emptyChild.ID}, vaultID, uid).Return(int64(0), nil)
+	fileRepo.On("ListByFIDsCount", mock.Anything, []int64{emptyChild.ID}, vaultID, uid).Return(int64(0), nil)
+	folderRepo.On("Update", mock.Anything, mock.MatchedBy(func(f *domain.Folder) bool {
+		return f.ID == emptyChild.ID && f.Action == domain.FolderActionDelete
+	}), uid).Return(emptyChild, nil)
+
+	folderRepo.On("GetAllByPathHash", mock.Anything, nonEmptyParent.PathHash, vaultID, uid).Return([]*domain.Folder{nonEmptyParent}, nil)
+	folderRepo.On("GetByFID", mock.Anything, nonEmptyParent.ID, vaultID, uid).Return([]*domain.Folder{}, nil)
+	noteRepo.On("ListByFIDsCount", mock.Anything, []int64{nonEmptyParent.ID}, vaultID, uid).Return(int64(1), nil)
+
+	svc := &folderService{
+		folderRepo: folderRepo,
+		noteRepo:   noteRepo,
+		fileRepo:   fileRepo,
+	}
+
+	err := svc.CleanupEmptyAncestors(ctx, uid, vaultID, "Projects/Archive/moved.md")
+
+	assert.NoError(t, err)
+	folderRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+	fileRepo.AssertExpectations(t)
 }

--- a/internal/service/mocks/mock_folder_service.go
+++ b/internal/service/mocks/mock_folder_service.go
@@ -61,6 +61,14 @@ func (m *MockFolderService) Delete(ctx context.Context, uid int64, params *dto.F
 	return nil, args.Error(1)
 }
 
+func (m *MockFolderService) DeleteTree(ctx context.Context, uid int64, params *dto.FolderDeleteRequest) (*dto.FolderDTO, error) {
+	args := m.Called(ctx, uid, params)
+	if v := args.Get(0); v != nil {
+		return v.(*dto.FolderDTO), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *MockFolderService) Rename(ctx context.Context, uid int64, params *dto.FolderRenameRequest) (*dto.FolderDTO, *dto.FolderDTO, error) {
 	args := m.Called(ctx, uid, params)
 	var old, newF *dto.FolderDTO
@@ -92,6 +100,11 @@ func (m *MockFolderService) ListFiles(ctx context.Context, uid int64, params *dt
 func (m *MockFolderService) EnsurePathFID(ctx context.Context, uid int64, vaultID int64, path string) (int64, error) {
 	args := m.Called(ctx, uid, vaultID, path)
 	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockFolderService) CleanupEmptyAncestors(ctx context.Context, uid int64, vaultID int64, resourcePath string) error {
+	args := m.Called(ctx, uid, vaultID, resourcePath)
+	return args.Error(0)
 }
 
 func (m *MockFolderService) SyncResourceFID(ctx context.Context, uid int64, vaultID int64, noteIDs []int64, fileIDs []int64) error {

--- a/internal/service/note_service.go
+++ b/internal/service/note_service.go
@@ -688,6 +688,14 @@ func (s *noteService) Rename(ctx context.Context, uid int64, params *dto.NoteRen
 		}
 
 		go s.folderService.SyncResourceFID(context.Background(), uid, vaultID, []int64{newNoteCreated.ID}, nil)
+		if err := s.folderService.CleanupEmptyAncestors(ctx, uid, vaultID, oldPath); err != nil {
+			zap.L().Warn("noteService.Rename: cleanup empty ancestor folders failed",
+				zap.Int64("uid", uid),
+				zap.Int64("vaultID", vaultID),
+				zap.String("oldPath", oldPath),
+				zap.Error(err),
+			)
+		}
 		go s.Migrate(context.Background(), n.ID, newNoteCreated.ID, uid)
 		if s.backupService != nil {
 			go s.backupService.NotifyUpdated(uid)


### PR DESCRIPTION
## Summary
- add an MCP `folder_delete` tool that recursively soft-deletes a vault folder tree
- prune empty ancestor folders after note/file rename operations
- guard recursive path-prefix queries with exact path-boundary filtering to avoid wildcard sibling matches

## Safety notes
- existing `FolderService.Delete` behavior is unchanged for REST/WebSocket sync callers
- recursive delete rejects empty/root folder paths
- note/file/folder deletion remains soft-delete based
- path-prefix results are post-filtered so `%` and `_` in folder names cannot delete sibling paths

## Validation
- `go test ./...`

Closes #358
