### PR TITLE
fix: quest_install.sh reads config/lastVersion as primary version source

### DIFF
--- a/scripts/quest_install.sh
+++ b/scripts/quest_install.sh
@@ -116,6 +116,7 @@ step() { echo -e "${_STEP}${_BLUE}$1${_RESET}"; }
 # --- Language Support ---
 LANG_CONF="$HOME/.fast-note-sync.lang"
 VERSION_CONF="$INSTALL_DIR/.version"
+VERSION_CONF_GO="$INSTALL_DIR/config/lastVersion"
 CURRENT_LANG="en" # Default to English
 INSTALLED_VER=""
 
@@ -340,10 +341,22 @@ parse_mirror_from_args "$@"
 
 # --- Version Tracking // 版本追踪 ---
 load_version() {
+    INSTALLED_VER=""
+    local go_ver="" shell_ver=""
+    if [ -f "$VERSION_CONF_GO" ]; then
+        go_ver=$(cat "$VERSION_CONF_GO" 2>/dev/null | tr -d '[:space:]' || echo "")
+    fi
     if [ -f "$VERSION_CONF" ]; then
-        INSTALLED_VER=$(cat "$VERSION_CONF" 2>/dev/null | tr -d '[:space:]' || echo "")
-    else
-        INSTALLED_VER=""
+        shell_ver=$(cat "$VERSION_CONF" 2>/dev/null | tr -d '[:space:]' || echo "")
+    fi
+    if [ -n "$go_ver" ]; then
+        INSTALLED_VER="$go_ver"
+        # Sync .version to match config/lastVersion when they differ
+        if [ "$go_ver" != "$shell_ver" ] && [ -d "$INSTALL_DIR" ]; then
+            echo "$go_ver" | tee "$VERSION_CONF" >/dev/null 2>&1 || true
+        fi
+    elif [ -n "$shell_ver" ]; then
+        INSTALLED_VER="$shell_ver"
     fi
 }
 


### PR DESCRIPTION
## 概述

修复 `quest_install.sh` 管理脚本显示的"当前版本"与实际运行的服务版本不一致的问题。

通过 WebGUI 或插件升级服务端后，脚本  banner 中的版本号仍是旧值，因为其仅读取 `.version` 文件，而 WebGUI/Plugin 升级走的是 Go 内部 API，Go 服务升级后只更新`config/lastVersion`，`.version` 永不被更新。

## 变更内容

- **新增 `VERSION_CONF_GO`**：指向 `$INSTALL_DIR/config/lastVersion`
- **`load_version()` 优先级调整 + 自动同步**：
  - 先读取 `config/lastVersion`，不存在则回退到 `.version`（向后兼容）
  - 当 `config/lastVersion` 存在且与 `.version` 不一致时，自动将 `.version` 同步为 `config/lastVersion` 的内容
  - 无论 `config/lastVersion` 大于或小于 `.version`，都进行同步（保证 `.version` 始终反映实际运行版本）
- **`save_version()` 不变**：继续写入 `.version`，不碰 `config/lastVersion`，避免干扰 Go 服务的 Migration 跳过逻辑（`runningVersion <= lastVersion` 时跳过）