### PR TITLE
fix: auto-detect source fallback + latency-aware probing

### DIFF
--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -1280,6 +1280,34 @@ Schema: `app.Res`
 
 ---
 
+### Probe version source latency
+**Endpoint**: `GET /api/version/probe`
+
+Parallel-probe GitHub and CNB release endpoints, return reachability, latency, recommended source and current selected mode
+
+**Parameters**:
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| token | header | string | ✓ | Auth Token |
+
+**Success Response (200)**:
+Schema: `app.Res{data=dto.SourceProbeDTO}`
+
+```json
+{
+  "code": 1,
+  "msg": "Success",
+  "data": {
+    "github": { "ok": true, "latencyMs": 280 },
+    "cnb": { "ok": true, "latencyMs": 52 },
+    "recommended": "cnb",
+    "selectedMode": "auto"
+  }
+}
+```
+
+---
+
 ## User APIs
 
 ### Change user password

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5125,6 +5125,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/version/probe": {
+            "get": {
+                "security": [
+                    {
+                        "UserAuthToken": []
+                    }
+                ],
+                "description": "Parallel-probe GitHub and CNB release endpoints, return reachability, latency, recommended source and current selected mode",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Probe version sources latency",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/app.Res"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.SourceProbeDTO"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/api/webgui/config": {
             "get": {
                 "description": "Get non-sensitive configuration required for frontend display, such as font settings, registration status, etc.",
@@ -5279,31 +5316,6 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
-        },
-        "diffmatchpatch.Diff": {
-            "type": "object",
-            "properties": {
-                "text": {
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/diffmatchpatch.Operation"
-                }
-            }
-        },
-        "diffmatchpatch.Operation": {
-            "type": "integer",
-            "format": "int32",
-            "enum": [
-                -1,
-                1,
-                0
-            ],
-            "x-enum-varnames": [
-                "DiffDelete",
-                "DiffInsert",
-                "DiffEqual"
-            ]
         },
         "dto.AdminCPUInfo": {
             "type": "object",
@@ -6686,7 +6698,7 @@ const docTemplate = `{
                     "description": "Text differences // 文本差异内容",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/diffmatchpatch.Diff"
+                        "type": "object"
                     }
                 },
                 "id": {
@@ -7516,6 +7528,54 @@ const docTemplate = `{
                     "description": "Vault name // 库名",
                     "type": "string",
                     "example": "work"
+                }
+            }
+        },
+        "dto.SourceProbeDTO": {
+            "description": "Probe result containing GitHub/CNB reachability, latency, recommended source and current mode",
+            "type": "object",
+            "properties": {
+                "cnb": {
+                    "description": "CNB probe result // CNB 探测结果",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.SourceProbeItem"
+                        }
+                    ]
+                },
+                "github": {
+                    "description": "GitHub probe result // GitHub 探测结果",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.SourceProbeItem"
+                        }
+                    ]
+                },
+                "recommended": {
+                    "description": "Recommended source: \"github\" or \"cnb\" // 推荐源",
+                    "type": "string",
+                    "example": "github"
+                },
+                "selectedMode": {
+                    "description": "Current configured pull-source mode // 当前配置的选源模式",
+                    "type": "string",
+                    "example": "auto"
+                }
+            }
+        },
+        "dto.SourceProbeItem": {
+            "description": "Single source probe result: reachability and latency",
+            "type": "object",
+            "properties": {
+                "latencyMs": {
+                    "description": "Round-trip latency in ms // 往返延迟（毫秒）",
+                    "type": "integer",
+                    "example": 280
+                },
+                "ok": {
+                    "description": "Whether the source is reachable // 该源是否可达",
+                    "type": "boolean",
+                    "example": true
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5119,6 +5119,43 @@
                 }
             }
         },
+        "/api/version/probe": {
+            "get": {
+                "security": [
+                    {
+                        "UserAuthToken": []
+                    }
+                ],
+                "description": "Parallel-probe GitHub and CNB release endpoints, return reachability, latency, recommended source and current selected mode",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Probe version sources latency",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/app.Res"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.SourceProbeDTO"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/api/webgui/config": {
             "get": {
                 "description": "Get non-sensitive configuration required for frontend display, such as font settings, registration status, etc.",
@@ -5273,31 +5310,6 @@
                     "type": "string"
                 }
             }
-        },
-        "diffmatchpatch.Diff": {
-            "type": "object",
-            "properties": {
-                "text": {
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/diffmatchpatch.Operation"
-                }
-            }
-        },
-        "diffmatchpatch.Operation": {
-            "type": "integer",
-            "format": "int32",
-            "enum": [
-                -1,
-                1,
-                0
-            ],
-            "x-enum-varnames": [
-                "DiffDelete",
-                "DiffInsert",
-                "DiffEqual"
-            ]
         },
         "dto.AdminCPUInfo": {
             "type": "object",
@@ -6680,7 +6692,7 @@
                     "description": "Text differences // 文本差异内容",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/diffmatchpatch.Diff"
+                        "type": "object"
                     }
                 },
                 "id": {
@@ -7510,6 +7522,54 @@
                     "description": "Vault name // 库名",
                     "type": "string",
                     "example": "work"
+                }
+            }
+        },
+        "dto.SourceProbeDTO": {
+            "description": "Probe result containing GitHub/CNB reachability, latency, recommended source and current mode",
+            "type": "object",
+            "properties": {
+                "cnb": {
+                    "description": "CNB probe result // CNB 探测结果",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.SourceProbeItem"
+                        }
+                    ]
+                },
+                "github": {
+                    "description": "GitHub probe result // GitHub 探测结果",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.SourceProbeItem"
+                        }
+                    ]
+                },
+                "recommended": {
+                    "description": "Recommended source: \"github\" or \"cnb\" // 推荐源",
+                    "type": "string",
+                    "example": "github"
+                },
+                "selectedMode": {
+                    "description": "Current configured pull-source mode // 当前配置的选源模式",
+                    "type": "string",
+                    "example": "auto"
+                }
+            }
+        },
+        "dto.SourceProbeItem": {
+            "description": "Single source probe result: reachability and latency",
+            "type": "object",
+            "properties": {
+                "latencyMs": {
+                    "description": "Round-trip latency in ms // 往返延迟（毫秒）",
+                    "type": "integer",
+                    "example": 280
+                },
+                "ok": {
+                    "description": "Whether the source is reachable // 该源是否可达",
+                    "type": "boolean",
+                    "example": true
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -82,24 +82,6 @@ definitions:
       uid:
         type: string
     type: object
-  diffmatchpatch.Diff:
-    properties:
-      text:
-        type: string
-      type:
-        $ref: '#/definitions/diffmatchpatch.Operation'
-    type: object
-  diffmatchpatch.Operation:
-    enum:
-    - -1
-    - 1
-    - 0
-    format: int32
-    type: integer
-    x-enum-varnames:
-    - DiffDelete
-    - DiffInsert
-    - DiffEqual
   dto.AdminCPUInfo:
     properties:
       loadAvg:
@@ -1110,7 +1092,7 @@ definitions:
       diffs:
         description: Text differences // 文本差异内容
         items:
-          $ref: '#/definitions/diffmatchpatch.Diff'
+          type: object
         type: array
       id:
         description: History entry ID // 历史项 ID
@@ -1734,6 +1716,39 @@ definitions:
     - path
     - pathHash
     - vault
+    type: object
+  dto.SourceProbeDTO:
+    description: Probe result containing GitHub/CNB reachability, latency, recommended
+      source and current mode
+    properties:
+      cnb:
+        allOf:
+        - $ref: '#/definitions/dto.SourceProbeItem'
+        description: CNB probe result // CNB 探测结果
+      github:
+        allOf:
+        - $ref: '#/definitions/dto.SourceProbeItem'
+        description: GitHub probe result // GitHub 探测结果
+      recommended:
+        description: 'Recommended source: "github" or "cnb" // 推荐源'
+        example: github
+        type: string
+      selectedMode:
+        description: Current configured pull-source mode // 当前配置的选源模式
+        example: auto
+        type: string
+    type: object
+  dto.SourceProbeItem:
+    description: 'Single source probe result: reachability and latency'
+    properties:
+      latencyMs:
+        description: Round-trip latency in ms // 往返延迟（毫秒）
+        example: 280
+        type: integer
+      ok:
+        description: Whether the source is reachable // 该源是否可达
+        example: true
+        type: boolean
     type: object
   dto.StorageDTO:
     properties:
@@ -5200,6 +5215,27 @@ paths:
                   $ref: '#/definitions/dto.VersionDTO'
               type: object
       summary: Get server version info
+      tags:
+      - System
+  /api/version/probe:
+    get:
+      description: Parallel-probe GitHub and CNB release endpoints, return reachability,
+        latency, recommended source and current selected mode
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            allOf:
+            - $ref: '#/definitions/app.Res'
+            - properties:
+                data:
+                  $ref: '#/definitions/dto.SourceProbeDTO'
+              type: object
+      security:
+      - UserAuthToken: []
+      summary: Probe version sources latency
       tags:
       - System
   /api/webgui/config:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/haierkeys/fast-note-sync-service/internal/service"
 	pkgapp "github.com/haierkeys/fast-note-sync-service/pkg/app"
+	"github.com/haierkeys/fast-note-sync-service/pkg/fileurl"
 	"github.com/haierkeys/fast-note-sync-service/pkg/workerpool"
 	"github.com/haierkeys/fast-note-sync-service/pkg/writequeue"
 	"golang.org/x/mod/semver"
@@ -315,6 +316,21 @@ func (a *App) GetTokenService() any {
 // IsPullFromGitHub 返回当前拉取源是否为 GitHub
 func (a *App) IsPullFromGitHub() bool {
 	return a.sourceSelector.IsGitHub()
+}
+
+// SourceSelector returns the underlying SourceSelector, exposing Probe/Snapshot
+// for the version-probe API and webgui latency panel.
+// SourceSelector 返回底层的 SourceSelector，供版本探测接口与前端测速面板使用。
+func (a *App) SourceSelector() *fileurl.SourceSelector {
+	return a.sourceSelector
+}
+
+// SetPullSourceMode updates the runtime source selection mode and invalidates
+// the cached probe snapshot. Called after config hot-reload changes pull-source.
+// SetPullSourceMode 更新运行时的选源模式并使缓存的探测快照失效，
+// 在配置热重载修改 pull-source 后调用。
+func (a *App) SetPullSourceMode(mode string) {
+	a.sourceSelector.SetMode(mode)
 }
 
 // ExecuteWrite executes write operation (serialized through Write Queue)

--- a/internal/dto/app_dto.go
+++ b/internal/dto/app_dto.go
@@ -28,3 +28,22 @@ type VersionDTO struct {
 type UpgradeRequest struct {
 	Version string `form:"version" binding:"required"` // Version to upgrade (e.g. 2.0.10 or latest) // 升级版本
 }
+
+// SourceProbeItem is one source's reachability + latency result.
+// SourceProbeItem 单个源的可达性与延迟结果。
+type SourceProbeItem struct {
+	OK        bool  `json:"ok"`        // Whether the source is reachable // 该源是否可达
+	LatencyMs int64 `json:"latencyMs"` // Round-trip latency in ms // 往返延迟（毫秒）
+}
+
+// SourceProbeDTO is the payload returned by GET /api/version/probe, consumed by
+// the webgui "test latency" panel. Recommended is "github" or "cnb"; SelectedMode
+// is the current configured pull-source mode (auto|github|cnb).
+// SourceProbeDTO 是 GET /api/version/probe 的响应，供 webgui「测试延迟」面板使用。
+// Recommended 为推荐的源（github 或 cnb）；SelectedMode 为当前配置的选源模式。
+type SourceProbeDTO struct {
+	GitHub       SourceProbeItem `json:"github"`
+	CNB          SourceProbeItem `json:"cnb"`
+	Recommended  string          `json:"recommended"`  // "github" or "cnb" // 推荐源
+	SelectedMode string          `json:"selectedMode"` // current configured mode // 当前配置的模式
+}

--- a/internal/dto/app_dto.go
+++ b/internal/dto/app_dto.go
@@ -31,9 +31,10 @@ type UpgradeRequest struct {
 
 // SourceProbeItem is one source's reachability + latency result.
 // SourceProbeItem 单个源的可达性与延迟结果。
+// @Description Single source probe result: reachability and latency
 type SourceProbeItem struct {
-	OK        bool  `json:"ok"`        // Whether the source is reachable // 该源是否可达
-	LatencyMs int64 `json:"latencyMs"` // Round-trip latency in ms // 往返延迟（毫秒）
+	OK        bool  `json:"ok" example:"true"`                            // Whether the source is reachable // 该源是否可达
+	LatencyMs int64 `json:"latencyMs" example:"280"`                      // Round-trip latency in ms // 往返延迟（毫秒）
 }
 
 // SourceProbeDTO is the payload returned by GET /api/version/probe, consumed by
@@ -41,9 +42,10 @@ type SourceProbeItem struct {
 // is the current configured pull-source mode (auto|github|cnb).
 // SourceProbeDTO 是 GET /api/version/probe 的响应，供 webgui「测试延迟」面板使用。
 // Recommended 为推荐的源（github 或 cnb）；SelectedMode 为当前配置的选源模式。
+// @Description Probe result containing GitHub/CNB reachability, latency, recommended source and current mode
 type SourceProbeDTO struct {
-	GitHub       SourceProbeItem `json:"github"`
-	CNB          SourceProbeItem `json:"cnb"`
-	Recommended  string          `json:"recommended"`  // "github" or "cnb" // 推荐源
-	SelectedMode string          `json:"selectedMode"` // current configured mode // 当前配置的模式
+	GitHub       SourceProbeItem `json:"github"`       // GitHub probe result // GitHub 探测结果
+	CNB          SourceProbeItem `json:"cnb"`          // CNB probe result // CNB 探测结果
+	Recommended  string          `json:"recommended" example:"github"` // Recommended source: "github" or "cnb" // 推荐源
+	SelectedMode string          `json:"selectedMode" example:"auto"`  // Current configured pull-source mode // 当前配置的选源模式
 }

--- a/internal/dto/note_dto.go
+++ b/internal/dto/note_dto.go
@@ -293,7 +293,7 @@ type NoteHistoryDTO struct {
 	NoteID        int64                 `json:"noteId" form:"noteId"`               // Associated note ID // 笔记 ID
 	VaultID       int64                 `json:"vaultId" form:"vaultId"`             // Associated vault ID // 保险库 ID
 	Path          string                `json:"path" form:"path"`                   // Note path at that time // 当时的笔记路径
-	Diffs         []diffmatchpatch.Diff `json:"diffs"`                              // Text differences // 文本差异内容
+	Diffs         []diffmatchpatch.Diff `json:"diffs" swaggertype:"array,object"`    // Text differences // 文本差异内容
 	Content       string                `json:"content" form:"content"`             // Full historical content // 完整历史内容
 	ContentHash   string                `json:"contentHash" form:"contentHash"`     // Content hash // 内容哈希
 	ClientName    string                `json:"clientName" form:"clientName"`       // Client that made changes // 产生变更的客户端

--- a/internal/routers/api_router/handler_admin_control.go
+++ b/internal/routers/api_router/handler_admin_control.go
@@ -332,6 +332,10 @@ func (h *AdminControlHandler) UpdateConfig(c *gin.Context) {
 	}
 	if params.PullSource != nil {
 		cfg.App.PullSource = *params.PullSource
+		// Sync the running SourceSelector so the change takes effect immediately
+		// instead of waiting for a server restart.
+		// 同步到运行中的 SourceSelector，使改动立即生效，无需重启服务端。
+		h.App.SetPullSourceMode(*params.PullSource)
 	}
 	if params.PullReleaseChannel != nil {
 		cfg.App.PullReleaseChannel = *params.PullReleaseChannel
@@ -1144,14 +1148,22 @@ func (h *AdminControlHandler) Upgrade(c *gin.Context) {
 	versionRaw := strings.TrimPrefix(version, "v")
 
 	// Determine download URL
-	// 确定下载地址
+	// At upgrade time, probe both sources in auto mode to pick the best one
+	// rather than relying on the cached background-task result.
+	// 确定下载地址：auto 模式在升级时主动探测两源，不依赖后台任务缓存。
+	useGitHub := checkInfo.GithubAvailable
+	if cfg.App.PullSource == "auto" {
+		snap := h.App.SourceSelector().Probe(c.Request.Context())
+		useGitHub = snap.UseGitHub
+	}
+
 	goos := runtime.GOOS
 	goarch := runtime.GOARCH
 
 	// Example: fast-note-sync-service-2.0.10-linux-amd64.tar.gz
 	fileName := fmt.Sprintf("fast-note-sync-service-%s-%s-%s.tar.gz", versionRaw, goos, goarch)
 	downloadURL := ""
-	if checkInfo.GithubAvailable {
+	if useGitHub {
 		// GitHub releases/download/[tag]/[filename]
 		// Based on user feedback: URL should NOT have 'v' in the tag part if the tag itself doesn't have it
 		downloadURL = fmt.Sprintf("https://github.com/haierkeys/fast-note-sync-service/releases/download/%s/%s", versionRaw, fileName)

--- a/internal/routers/api_router/handler_version.go
+++ b/internal/routers/api_router/handler_version.go
@@ -8,6 +8,7 @@ import (
 	"github.com/haierkeys/fast-note-sync-service/internal/dto"
 	pkgapp "github.com/haierkeys/fast-note-sync-service/pkg/app"
 	"github.com/haierkeys/fast-note-sync-service/pkg/code"
+	"github.com/haierkeys/fast-note-sync-service/pkg/fileurl"
 )
 
 // VersionHandler version info API router handler
@@ -52,6 +53,36 @@ func (h *VersionHandler) ServerVersion(c *gin.Context) {
 		PluginVersionNewChangelog:        checkInfo.PluginVersionNewChangelog,
 		PluginVersionNewChangelogContent: checkInfo.PluginVersionNewChangelogContent,
 		PluginVersionHistory:             checkInfo.PluginVersionHistory,
+	}))
+}
+
+// ProbeSources probes GitHub and CNB release endpoints in parallel and reports
+// reachability + latency for each, plus the recommended source. Used by the
+// webgui settings "test latency" panel.
+// @Summary Probe version sources latency
+// @Description Parallel-probe GitHub and CNB release endpoints, return reachability, latency and recommended source
+// @Tags System
+// @Produce json
+// @Success 200 {object} pkgapp.Res{data=dto.SourceProbeDTO} "Success"
+// @Router /api/version/probe [get]
+func (h *VersionHandler) ProbeSources(c *gin.Context) {
+	response := pkgapp.NewResponse(c)
+	snap := h.App.SourceSelector().Probe(c.Request.Context())
+	recommended := fileurl.SourceCNB
+	if snap.UseGitHub {
+		recommended = fileurl.SourceGitHub
+	}
+	response.ToResponse(code.Success.WithData(dto.SourceProbeDTO{
+		GitHub: dto.SourceProbeItem{
+			OK:        snap.GitHub.OK,
+			LatencyMs: snap.GitHub.LatencyMs,
+		},
+		CNB: dto.SourceProbeItem{
+			OK:        snap.CNB.OK,
+			LatencyMs: snap.CNB.LatencyMs,
+		},
+		Recommended:  recommended,
+		SelectedMode: h.App.SourceSelector().Mode(),
 	}))
 }
 

--- a/internal/routers/api_router/handler_version.go
+++ b/internal/routers/api_router/handler_version.go
@@ -60,9 +60,10 @@ func (h *VersionHandler) ServerVersion(c *gin.Context) {
 // reachability + latency for each, plus the recommended source. Used by the
 // webgui settings "test latency" panel.
 // @Summary Probe version sources latency
-// @Description Parallel-probe GitHub and CNB release endpoints, return reachability, latency and recommended source
+// @Description Parallel-probe GitHub and CNB release endpoints, return reachability, latency, recommended source and current selected mode
 // @Tags System
 // @Produce json
+// @Security UserAuthToken
 // @Success 200 {object} pkgapp.Res{data=dto.SourceProbeDTO} "Success"
 // @Router /api/version/probe [get]
 func (h *VersionHandler) ProbeSources(c *gin.Context) {

--- a/internal/routers/router_api.go
+++ b/internal/routers/router_api.go
@@ -112,6 +112,10 @@ func registerAPIRoutes(r *gin.Engine, appContainer *app.App, wss *pkgapp.Websock
 			auth.GET("/admin/ws_clients", adminControlHandler.GetWSClients)
 			auth.DELETE("/admin/ws_client/:traceId", adminControlHandler.KickWSClient)
 
+			// Version source latency probe (auth required: triggers real outbound requests)
+			// 版本源延迟探测（需认证：会触发真实的外部网络请求）
+			auth.GET("/version/probe", versionHandler.ProbeSources)
+
 			auth.GET("/user/info", userHandler.UserInfo)
 			auth.POST("/oauth/stytch/authorize/start", stytchOAuthHandler.AuthorizeStart)
 			auth.POST("/oauth/stytch/authorize/submit", stytchOAuthHandler.AuthorizeSubmit)

--- a/internal/task/task_check_version.go
+++ b/internal/task/task_check_version.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/haierkeys/fast-note-sync-service/internal/app"
 	pkgapp "github.com/haierkeys/fast-note-sync-service/pkg/app"
+	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 )
 
@@ -28,6 +29,12 @@ const (
 	CNBPluginURL         = "https://cnb.cool/" + PluginRepoPath
 	CNBServiceToken      = "58tjez3744HL9Z10cRaCHdeEPhK"
 	CNBPluginToken       = "9pFNKcjlej36e0w6MHKT6YMn53G"
+
+	// fetchHTTPTimeout bounds each release-list HTTP request so a hung source
+	// can't stall the whole task; the task-layer fallback then retries the other source.
+	// fetchHTTPTimeout 限制单次 release 列表请求的耗时，防止某源卡死拖住整个任务；
+	// task 层 fallback 会回退到另一源重试。
+	fetchHTTPTimeout = 8 * time.Second
 )
 
 type GitHubAsset struct {
@@ -53,6 +60,15 @@ type GitHubTag struct {
 	Name string `json:"name"`
 }
 
+// releaseSource identifies which source a release list came from.
+// releaseSource 标识 release 列表来自哪个源。
+type releaseSource string
+
+const (
+	sourceGitHub releaseSource = "github"
+	sourceCNB    releaseSource = "cnb"
+)
+
 type CheckVersionTask struct {
 	app *app.App
 }
@@ -70,68 +86,40 @@ func (t *CheckVersionTask) Name() string {
 }
 
 func (t *CheckVersionTask) Run(ctx context.Context) error {
-	isGitHub := t.app.IsPullFromGitHub()
+	// Primary source is decided by SourceSelector (auto probes real release
+	// endpoints, with latency-aware switching). The task-layer fallback below
+	// guarantees that even if the probe picked the wrong source, the other one
+	// is retried once before giving up.
+	// 主源由 SourceSelector 决定（auto 模式探测真实 release 接口 + 延迟感知切换）。
+	// 下方 task 层 fallback 保证即使探测选错源，也会回退另一源重试一次。
+	githubFirst := t.app.IsPullFromGitHub()
+
+	// Service releases (with fallback)
+	// 服务端版本（带回退）
+	serviceUsedGitHub, serviceReleases, serviceLink, serviceChangelog, serviceChangelogContent, err :=
+		t.fetchReleasesWithFallback(ctx, GitHubServiceReleaseURL, CNBServiceReleaseURL, CNBServiceToken, true, githubFirst)
+	if err != nil {
+		return fmt.Errorf("fetch service releases: %w", err)
+	}
+
+	// Plugin releases (prefer the same source the service fetch actually used,
+	// so service & plugin versions come from the same mirror)
+	// 插件版本（优先用服务端实际命中的源，保证服务端与插件版本来自同一镜像）
+	pluginReleases, pluginLink, pluginChangelog, pluginChangelogContent, perr :=
+		t.fetchReleasesWithFallbackLinksOnly(ctx, GitHubPluginReleaseURL, CNBPluginReleaseURL, CNBPluginToken, false, serviceUsedGitHub)
+	if perr != nil {
+		// Plugin version is best-effort; don't fail the whole task if only plugin fetch errors.
+		// 插件版本尽力而为：仅插件抓取失败不应导致整个任务失败。
+		t.app.Logger().Warn("check_version: plugin releases fetch failed, keeping service result only", zap.Error(perr))
+		pluginReleases = nil
+	}
 
 	var serviceLatest, pluginLatest string
-	var serviceLink, pluginLink string
-	var serviceChangelog, pluginChangelog string
-	var err error
-
-	var serviceChangelogContent, pluginChangelogContent string
-	var serviceReleases, pluginReleases []pkgapp.HistoricalVersion
-
-	if isGitHub {
-		serviceReleases, err = t.fetchGitHubReleases(GitHubServiceReleaseURL)
-		if err != nil {
-			return err
-		}
-
-		pluginReleases, err = t.fetchGitHubReleases(GitHubPluginReleaseURL)
-		if err != nil {
-			return err
-		}
-
-		if len(serviceReleases) > 0 {
-			serviceLatest = serviceReleases[0].Version
-			serviceChangelogContent = serviceReleases[0].ChangelogContent
-			serviceLatestClean := strings.TrimPrefix(serviceLatest, "v")
-			serviceLink = ServiceRepoURL + "/releases/tag/" + serviceLatestClean
-			serviceChangelog = ServiceRepoURL + "/releases/download/" + serviceLatestClean + "/changelog.txt"
-		}
-
-		if len(pluginReleases) > 0 {
-			pluginLatest = pluginReleases[0].Version
-			pluginChangelogContent = pluginReleases[0].ChangelogContent
-			pluginLatestClean := strings.TrimPrefix(pluginLatest, "v")
-			pluginLink = PluginRepoURL + "/releases/tag/" + pluginLatestClean
-			pluginChangelog = PluginRepoURL + "/releases/download/" + pluginLatestClean + "/changelog.txt"
-		}
-
-	} else {
-		serviceReleases, err = t.fetchCNBVersion(CNBServiceReleaseURL, CNBServiceToken)
-		if err != nil {
-			return err
-		}
-		pluginReleases, err = t.fetchCNBVersion(CNBPluginReleaseURL, CNBPluginToken)
-		if err != nil {
-			return err
-		}
-
-		if len(serviceReleases) > 0 {
-			serviceLatest = serviceReleases[0].Version
-			serviceChangelogContent = serviceReleases[0].ChangelogContent
-			serviceLatestClean := strings.TrimPrefix(serviceLatest, "v")
-			serviceLink = CNBServiceURL + "/-/releases/tag/" + serviceLatestClean
-			serviceChangelog = CNBServiceURL + "/-/releases/download/" + serviceLatestClean + "/changelog.txt"
-		}
-
-		if len(pluginReleases) > 0 {
-			pluginLatest = pluginReleases[0].Version
-			pluginChangelogContent = pluginReleases[0].ChangelogContent
-			pluginLatestClean := strings.TrimPrefix(pluginLatest, "v")
-			pluginLink = CNBPluginURL + "/-/releases/tag/" + pluginLatestClean
-			pluginChangelog = CNBPluginURL + "/-/releases/download/" + pluginLatestClean + "/changelog.txt"
-		}
+	if len(serviceReleases) > 0 {
+		serviceLatest = serviceReleases[0].Version
+	}
+	if len(pluginReleases) > 0 {
+		pluginLatest = pluginReleases[0].Version
 	}
 
 	currentServiceVersion := t.app.Version().Version
@@ -148,7 +136,15 @@ func (t *CheckVersionTask) Run(ctx context.Context) error {
 	}
 
 	info := pkgapp.CheckVersionInfo{
-		GithubAvailable:                  isGitHub,
+		// GithubAvailable now means "the source the version info was ACTUALLY
+		// fetched from is GitHub". This keeps the upgrade download URL (decided
+		// from this field in handler_admin_control.Upgrade) consistent with the
+		// source that produced the version data, fixing the old probe/upgrade
+		// mismatch where the probe said GitHub but the download went 404.
+		// GithubAvailable 现在表示「版本信息实际命中的源是 GitHub」，使升级下载地址
+		// （在 handler_admin_control.Upgrade 中由本字段决定）与产生版本数据的源一致，
+		// 修复过去「探测说 GitHub 但下载 404」的不一致。
+		GithubAvailable:                  serviceUsedGitHub,
 		VersionNewName:                   serviceLatest,
 		VersionIsNew:                     serviceLatest != "" && semver.Compare(serviceLatest, currentServiceVersion) > 0,
 		VersionNewLink:                   serviceLink,
@@ -170,6 +166,98 @@ func (t *CheckVersionTask) Run(ctx context.Context) error {
 	return nil
 }
 
+// fetchReleasesWithFallback tries the primary source first; on failure/empty it
+// falls back to the other source once. Returns the source actually used and the
+// assembled release list + link/changelog for the latest release.
+// fetchReleasesWithFallback 先试主源；失败或为空时回退另一源重试一次。
+// 返回实际命中的源、已过滤的 release 列表，以及最新版的 link/changelog。
+func (t *CheckVersionTask) fetchReleasesWithFallback(
+	ctx context.Context, ghURL, cnbURL, cnbToken string, isService, githubFirst bool,
+) (usedGitHub bool, releases []pkgapp.HistoricalVersion, link, changelogLink, changelogContent string, err error) {
+	releases, link, changelogLink, changelogContent, usedGitHub, err = t.tryFetch(ctx, ghURL, cnbURL, cnbToken, isService, githubFirst)
+	if err == nil && len(releases) > 0 {
+		return usedGitHub, releases, link, changelogLink, changelogContent, nil
+	}
+	if err != nil {
+		t.app.Logger().Warn("check_version: primary source failed, falling back",
+			zap.Bool("githubFirst", githubFirst),
+			zap.Bool("isService", isService),
+			zap.Error(err))
+	} else {
+		t.app.Logger().Warn("check_version: primary source returned no releases, falling back",
+			zap.Bool("githubFirst", githubFirst),
+			zap.Bool("isService", isService))
+	}
+
+	// fallback to the other source
+	// 回退另一源
+	releases, link, changelogLink, changelogContent, usedGitHub, ferr := t.tryFetch(ctx, ghURL, cnbURL, cnbToken, isService, !githubFirst)
+	if ferr != nil {
+		if err == nil {
+			err = ferr
+		}
+		return githubFirst, nil, "", "", "", fmt.Errorf("both sources failed (primary err fallback): %w", ferr)
+	}
+	return usedGitHub, releases, link, changelogLink, changelogContent, nil
+}
+
+// fetchReleasesWithFallbackOnly is the variant returning links-only without the
+// usedGitHub being needed by callers that ignore it. Kept the signature explicit
+// for clarity in Run(); see fetchReleasesWithFallback for behavior.
+// fetchReleasesWithFallbackLinksOnly 与 fetchReleasesWithFallback 行为相同，
+// 供不需要 usedGitHub 的调用点使用（语义清晰）。
+func (t *CheckVersionTask) fetchReleasesWithFallbackLinksOnly(
+	ctx context.Context, ghURL, cnbURL, cnbToken string, isService, githubFirst bool,
+) ([]pkgapp.HistoricalVersion, string, string, string, error) {
+	_, releases, link, cl, clc, err := t.fetchReleasesWithFallback(ctx, ghURL, cnbURL, cnbToken, isService, githubFirst)
+	return releases, link, cl, clc, err
+}
+
+// tryFetch fetches from exactly one source (github or cnb) and assembles links.
+// tryFetch 只从一个源抓取（github 或 cnb）并拼装链接。
+func (t *CheckVersionTask) tryFetch(
+	ctx context.Context, ghURL, cnbURL, cnbToken string, isService, useGitHub bool,
+) (releases []pkgapp.HistoricalVersion, link, changelogLink, changelogContent string, usedGitHub bool, err error) {
+	if useGitHub {
+		releases, err = t.fetchGitHubReleasesCtx(ctx, ghURL)
+	} else {
+		releases, err = t.fetchCNBVersionCtx(ctx, cnbURL, cnbToken)
+	}
+	if err != nil {
+		return nil, "", "", "", useGitHub, err
+	}
+	link, changelogLink, changelogContent = buildLinks(releases, isService, useGitHub)
+	return releases, link, changelogLink, changelogContent, useGitHub, nil
+}
+
+// buildLinks assembles the release page / changelog URLs for the latest release,
+// depending on which source it came from.
+// buildLinks 根据来源源，为最新版拼装 release 页面与 changelog 的 URL。
+func buildLinks(releases []pkgapp.HistoricalVersion, isService, fromGitHub bool) (link, changelogLink, changelogContent string) {
+	if len(releases) == 0 {
+		return "", "", ""
+	}
+	latest := releases[0].Version
+	changelogContent = releases[0].ChangelogContent
+	latestClean := strings.TrimPrefix(latest, "v")
+	if fromGitHub {
+		base := ServiceRepoURL
+		if !isService {
+			base = PluginRepoURL
+		}
+		link = base + "/releases/tag/" + latestClean
+		changelogLink = base + "/releases/download/" + latestClean + "/changelog.txt"
+	} else {
+		base := CNBServiceURL
+		if !isService {
+			base = CNBPluginURL
+		}
+		link = base + "/-/releases/tag/" + latestClean
+		changelogLink = base + "/-/releases/download/" + latestClean + "/changelog.txt"
+	}
+	return link, changelogLink, changelogContent
+}
+
 // hasValidAssets checks if there is at least one uploaded zip or tar.gz file
 // hasValidAssets 检查是否包含至少一个已成功上传的 zip 或 tar.gz 资源文件
 func hasValidAssets(assets []GitHubAsset) bool {
@@ -184,8 +272,13 @@ func hasValidAssets(assets []GitHubAsset) bool {
 	return false
 }
 
-func (t *CheckVersionTask) fetchGitHubReleases(url string) ([]pkgapp.HistoricalVersion, error) {
-	resp, err := http.Get(url)
+func (t *CheckVersionTask) fetchGitHubReleasesCtx(ctx context.Context, url string) ([]pkgapp.HistoricalVersion, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	cli := &http.Client{Timeout: fetchHTTPTimeout}
+	resp, err := cli.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -227,8 +320,8 @@ func (t *CheckVersionTask) fetchGitHubReleases(url string) ([]pkgapp.HistoricalV
 	return result, nil
 }
 
-func (t *CheckVersionTask) fetchCNBVersion(url string, token string) ([]pkgapp.HistoricalVersion, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func (t *CheckVersionTask) fetchCNBVersionCtx(ctx context.Context, url string, token string) ([]pkgapp.HistoricalVersion, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +329,8 @@ func (t *CheckVersionTask) fetchCNBVersion(url string, token string) ([]pkgapp.H
 	req.Header.Set("Accept", "application/vnd.cnb.api+json")
 	req.Header.Set("Authorization", token)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	cli := &http.Client{Timeout: fetchHTTPTimeout}
+	resp, err := cli.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fileurl/source_selector.go
+++ b/pkg/fileurl/source_selector.go
@@ -1,7 +1,9 @@
 package fileurl
 
 import (
+	"context"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -10,52 +12,231 @@ const (
 	SourceGitHub = "github"
 	SourceCNB    = "cnb"
 
-	GitHubCheckURL = "https://api.github.com"
+	// GitHubProbeURL / CNBProbeURL are the real release endpoints used for probing.
+	// 探测目标使用真实的 release 接口，而不是根域名 —— 根域名可达不代表 release 接口可达
+	// （GitHub 对未鉴权的 /repos/.../releases 有 60 次/小时/IP 限流，命中限流根域名仍 200）。
+	GitHubProbeURL = "https://api.github.com/repos/haierkeys/fast-note-sync-service/releases"
+	CNBProbeURL    = "https://api.cnb.cool/haierkeys/fast-note-sync-service/-/releases"
+
+	// defaultProbeTimeout is the per-source probe timeout.
+	// 单源探测超时；超过即判定该源不可用，直接切换到另一源。
+	defaultProbeTimeout = 3 * time.Second
+	// defaultCacheTTL is how long a probe snapshot is reused before re-probing.
+	// 探测快照缓存时长；避免后台任务每 10 分钟轮询时反复打探测请求。
+	defaultCacheTTL = 5 * time.Minute
+
+	// latencySwitchFactor: when both sources are reachable, the slower one must
+	// be at least latencySwitchFactor × faster one AND exceed latencySwitchFloor
+	// before we switch. Prevents jitter between two equally-fast sources.
+	// 延迟差倍数阈值：双可达时，慢方 ≥ 2× 快方 且 慢方 ≥ 200ms 才切换，避免在两个
+	// 延迟接近的源之间反复抖动。
+	latencySwitchFactor = 2.0
+	latencySwitchFloor  = int64(200) // ms
 )
 
-// SourceSelector handles the logic of selecting the data source (GitHub or CNB)
-// SourceSelector 处理选择数据源（GitHub 或 CNB）的逻辑
-type SourceSelector struct {
-	mode      string
-	isGitHub  bool
-	lastCheck time.Time
+// ProbeResult is the reachability + latency result of a single source probe.
+// ProbeResult 单源探测结果（可达性 + 延迟）。
+type ProbeResult struct {
+	OK        bool  // true if the source responded with a non-5xx status
+	LatencyMs int64 // round-trip time in milliseconds (0 if request failed before any response)
 }
 
-// NewSourceSelector creates a new SourceSelector
-// NewSourceSelector 创建一个新的 SourceSelector
+// ProbeSnapshot is a point-in-time view of both sources produced by one parallel probe.
+// ProbeSnapshot 一次并行探测两源的快照，供前端测速面板展示与选源决策复用。
+type ProbeSnapshot struct {
+	GitHub     ProbeResult
+	CNB        ProbeResult
+	UseGitHub  bool      // derived recommended source based on the threshold strategy
+	At         time.Time // when this snapshot was taken
+}
+
+// SourceSelector handles the logic of selecting the data source (GitHub or CNB).
+// SourceSelector 处理选择数据源（GitHub 或 CNB）的逻辑。
+//
+// Concurrency: IsGitHub / Probe / Snapshot / SetMode are all goroutine-safe.
+// 并发安全：所有公开方法均可被多个 goroutine 并发调用（后台任务、HTTP handler、
+// WebSocket 广播都会调用 IsGitHub）。
+type SourceSelector struct {
+	mu       sync.Mutex
+	mode     string
+	snapshot *ProbeSnapshot
+	cacheTTL time.Duration
+}
+
+// NewSourceSelector creates a new SourceSelector.
+// NewSourceSelector 创建一个新的 SourceSelector。
 func NewSourceSelector(mode string) *SourceSelector {
 	return &SourceSelector{
-		mode: mode,
+		mode:     mode,
+		cacheTTL: defaultCacheTTL,
 	}
 }
 
-// IsGitHub returns whether the current source should be GitHub
-// IsGitHub 返回当前源是否应该为 GitHub
+// SetMode updates the selection mode (auto | github | cnb) at runtime.
+// SetMode 运行时更新选源模式（auto | github | cnb），例如配置热重载后。
+func (s *SourceSelector) SetMode(mode string) {
+	s.mu.Lock()
+	s.mode = mode
+	s.snapshot = nil // invalidate cached snapshot so the new mode takes effect immediately
+	s.mu.Unlock()
+}
+
+// IsGitHub returns whether the current source should be GitHub.
+// IsGitHub 返回当前推荐源是否为 GitHub。
+//
+// For explicit github/cnb modes it returns a fixed answer. For auto mode it
+// reuses a cached snapshot within cacheTTL, otherwise probes synchronously.
+// 显式 github/cnb 模式返回固定结果；auto 模式在缓存有效期内复用快照，否则同步探测。
 func (s *SourceSelector) IsGitHub() bool {
-	switch s.mode {
+	s.mu.Lock()
+	mode := s.mode
+	s.mu.Unlock()
+	switch mode {
 	case SourceGitHub:
 		return true
 	case SourceCNB:
 		return false
 	default:
-		// Auto mode or unknown mode
-		// 自动模式或未知模式
-		if time.Since(s.lastCheck) > 10*time.Minute {
-			s.isGitHub = s.checkGitHub()
-			s.lastCheck = time.Now()
-		}
-		return s.isGitHub
+		return s.recentSnapshot(context.Background()).UseGitHub
 	}
 }
 
-func (s *SourceSelector) checkGitHub() bool {
-	client := http.Client{
-		Timeout: 3 * time.Second,
+// Probe forces a fresh parallel probe of both sources (bypasses cache) and
+// caches the result. Intended for the webgui "test latency" button.
+// Probe 立即重新并行探测两源（绕过缓存）并缓存结果，供前端「测试延迟」按钮调用。
+func (s *SourceSelector) Probe(ctx context.Context) ProbeSnapshot {
+	snap := probeBoth(ctx)
+	s.mu.Lock()
+	s.snapshot = &snap
+	s.mu.Unlock()
+	return snap
+}
+
+// Snapshot returns the cached probe snapshot if still fresh, otherwise nil.
+// Snapshot 返回仍在有效期内的缓存快照；过期或从未探测过则返回 nil（前端展示用）。
+func (s *SourceSelector) Snapshot() *ProbeSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.snapshot == nil || time.Since(s.snapshot.At) > s.cacheTTL {
+		return nil
 	}
-	resp, err := client.Head(GitHubCheckURL)
-	if err != nil {
+	snap := *s.snapshot
+	return &snap
+}
+
+// Mode returns the current selection mode.
+// Mode 返回当前选源模式。
+func (s *SourceSelector) Mode() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mode
+}
+
+// recentSnapshot returns a fresh-enough snapshot, probing synchronously when the
+// cache is stale. Probe uses a bounded timeout derived from ctx (or the default).
+// recentSnapshot 返回足够新的快照；缓存过期时同步探测一次。
+func (s *SourceSelector) recentSnapshot(ctx context.Context) ProbeSnapshot {
+	s.mu.Lock()
+	snap := s.snapshot
+	mode := s.mode
+	s.mu.Unlock()
+	if snap != nil && time.Since(snap.At) <= s.cacheTTL {
+		return *snap
+	}
+	// Explicit modes don't need probing for selection, but still probe so that
+	// the frontend latency panel works regardless of mode.
+	// 显式模式下选源是固定的，但仍探测一次以便前端测速面板能展示延迟。
+	fresh := probeBoth(ctx)
+	if mode != SourceGitHub && mode != SourceCNB {
+		// auto: snapshot drives selection, cache it
+		// auto 模式：快照驱动选源，需要缓存
+		s.mu.Lock()
+		s.snapshot = &fresh
+		s.mu.Unlock()
+	}
+	return fresh
+}
+
+// probeBoth probes GitHub and CNB in parallel and derives the recommended source.
+// probeBoth 并行探测 GitHub 与 CNB，并基于阈值策略推导推荐源。
+func probeBoth(ctx context.Context) ProbeSnapshot {
+	ctx, cancel := context.WithTimeout(ctx, defaultProbeTimeout+500*time.Millisecond)
+	defer cancel()
+
+	var g, c ProbeResult
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		g = probeOne(ctx, GitHubProbeURL, "")
+	}()
+	go func() {
+		defer wg.Done()
+		c = probeOne(ctx, CNBProbeURL, "")
+	}()
+	wg.Wait()
+
+	return ProbeSnapshot{
+		GitHub:    g,
+		CNB:       c,
+		UseGitHub: pickSource(g, c),
+		At:        time.Now(),
+	}
+}
+
+// pickSource implements the threshold strategy:
+//  1. if exactly one source is reachable, pick it;
+//  2. if neither is reachable, default to GitHub and let the task-layer fallback retry handle it;
+//  3. if both are reachable, switch only when the slower one is at least
+//     latencySwitchFactor × the faster one AND exceeds latencySwitchFloor (anti-jitter).
+//
+// pickSource 实现阈值策略：
+//  1. 仅一源可达 → 选它；
+//  2. 两源都不可达 → 默认 GitHub，交由 task 层 fallback 重试兜底；
+//  3. 双可达 → 仅当慢方 ≥ 2× 快方 且 ≥ 200ms 才切，避免抖动。
+func pickSource(g, c ProbeResult) bool {
+	switch {
+	case g.OK && !c.OK:
+		return true
+	case !g.OK && c.OK:
 		return false
+	case !g.OK && !c.OK:
+		return true
+	default:
+		fast, slow := g.LatencyMs, c.LatencyMs
+		slowIsGitHub := false
+		if c.LatencyMs < g.LatencyMs {
+			fast, slow = c.LatencyMs, g.LatencyMs
+			slowIsGitHub = true
+		}
+		if slow >= latencySwitchFloor && float64(slow) >= latencySwitchFactor*float64(fast) {
+			// switch to the faster one
+			// 切到更快的那一方
+			return !slowIsGitHub
+		}
+		return true // close enough, keep GitHub as default
+	}
+}
+
+// probeOne issues a HEAD request against url with a bounded timeout and reports
+// reachability + latency. A 2xx/3xx response counts as reachable (CNB may 302).
+// probeOne 对 url 发起带超时的 HEAD 请求，返回可达性与延迟；2xx/3xx 视为可达（CNB 可能 302）。
+func probeOne(ctx context.Context, url, token string) ProbeResult {
+	cli := &http.Client{Timeout: defaultProbeTimeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return ProbeResult{OK: false}
+	}
+	if token != "" {
+		req.Header.Set("Authorization", token)
+	}
+	start := time.Now()
+	resp, err := cli.Do(req)
+	latency := time.Since(start).Milliseconds()
+	if err != nil {
+		return ProbeResult{OK: false, LatencyMs: latency}
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	ok := resp.StatusCode < http.StatusInternalServerError
+	return ProbeResult{OK: ok, LatencyMs: latency}
 }

--- a/pkg/fileurl/source_selector_test.go
+++ b/pkg/fileurl/source_selector_test.go
@@ -1,0 +1,99 @@
+package fileurl
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPickSourceTableDriven(t *testing.T) {
+	// pickSource implements the threshold strategy:
+	// - exactly one reachable -> pick it
+	// - neither reachable -> default GitHub (task-layer fallback retries)
+	// - both reachable -> switch only when slower >= 2x faster AND slower >= 200ms
+	// pickSource 实现阈值策略，见上注释。
+	cases := []struct {
+		name     string
+		g, c     ProbeResult
+		expected bool // true = GitHub
+	}{
+		{"only github reachable", ProbeResult{OK: true, LatencyMs: 100}, ProbeResult{OK: false}, true},
+		{"only cnb reachable", ProbeResult{OK: false}, ProbeResult{OK: true, LatencyMs: 100}, false},
+		{"both down -> default github", ProbeResult{OK: false}, ProbeResult{OK: false}, true},
+
+		// both reachable, latency close -> keep GitHub (anti-jitter)
+		{"both close, github slightly faster", ProbeResult{OK: true, LatencyMs: 100}, ProbeResult{OK: true, LatencyMs: 120}, true},
+		{"both close, cnb slightly faster", ProbeResult{OK: true, LatencyMs: 120}, ProbeResult{OK: true, LatencyMs: 100}, true},
+		{"both fast equal", ProbeResult{OK: true, LatencyMs: 50}, ProbeResult{OK: true, LatencyMs: 50}, true},
+
+		// both reachable, big difference -> switch to faster one
+		{"github much slower -> switch to cnb", ProbeResult{OK: true, LatencyMs: 600}, ProbeResult{OK: true, LatencyMs: 100}, false},
+		{"cnb much slower -> keep github", ProbeResult{OK: true, LatencyMs: 100}, ProbeResult{OK: true, LatencyMs: 600}, true},
+
+		// difference is 2x but under floor (200ms) -> no switch (anti-jitter on fast networks)
+		{"2x diff but under floor", ProbeResult{OK: true, LatencyMs: 30}, ProbeResult{OK: true, LatencyMs: 60}, true},
+
+		// difference big enough and over floor -> switch
+		{"github slow over floor 2x", ProbeResult{OK: true, LatencyMs: 450}, ProbeResult{OK: true, LatencyMs: 200}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pickSource(tc.g, tc.c)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestSourceSelectorExplicitModes(t *testing.T) {
+	s := NewSourceSelector(SourceGitHub)
+	assert.True(t, s.IsGitHub())
+	assert.Equal(t, SourceGitHub, s.Mode())
+
+	s2 := NewSourceSelector(SourceCNB)
+	assert.False(t, s2.IsGitHub())
+	assert.Equal(t, SourceCNB, s2.Mode())
+}
+
+func TestSourceSelectorSetModeInvalidatesSnapshot(t *testing.T) {
+	// Probe once to populate snapshot, then SetMode should clear it.
+	// 探测一次填充快照，随后 SetMode 应清空它。
+	s := NewSourceSelector(SourceAuto)
+	s.Probe(context.Background())
+	assert.NotNil(t, s.Snapshot(), "probe should populate a snapshot")
+
+	s.SetMode(SourceGitHub)
+	assert.Nil(t, s.Snapshot(), "SetMode must invalidate the cached snapshot")
+	assert.True(t, s.IsGitHub())
+}
+
+func TestSourceSelectorProbePopulatesSnapshot(t *testing.T) {
+	s := NewSourceSelector(SourceAuto)
+	snap := s.Probe(context.Background())
+	assert.Equal(t, snap.At, s.Snapshot().At, "Probe should cache the snapshot it returns")
+	// GitHub/CNB reachability is environment-dependent; just assert structural fields exist.
+	// GitHub/CNB 的可达性依赖网络环境，这里只断言结构字段存在。
+}
+
+func TestSourceSelectorConcurrentAccess(t *testing.T) {
+	// Run with `go test -race` to detect data races on IsGitHub/Probe/Snapshot/SetMode.
+	// 使用 `go test -race` 运行，检测 IsGitHub/Probe/Snapshot/SetMode 的数据竞争。
+	s := NewSourceSelector(SourceAuto)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(4)
+		go func() { defer wg.Done(); _ = s.IsGitHub() }()
+		go func() { defer wg.Done(); _ = s.Snapshot() }()
+		go func() { defer wg.Done(); s.Probe(context.Background()) }()
+		go func(j int) {
+			defer wg.Done()
+			if j%2 == 0 {
+				s.SetMode(SourceAuto)
+			} else {
+				s.SetMode(SourceGitHub)
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## 概述
Resolves #370, Resolves #263, Refs #386

修复升级时 GitHub 不可达时「自动检测」模式不切换 CNB、升级下载地址与探测结果撕裂等 4 个协同缺陷；新增并行延迟探测 + 阈值选源 + 升级时按需探测机制。

关联 WebGUI PR：https://github.com/haierkeys/fast-note-sync-webgui/pull/29

## 问题描述及原因

**复现条件**：WebGUI 设置页「版本检测源」选择「自动检测 (推荐)」，GitHub 因网络原因连不上。

**现象**：
1. 版本检测长时间无结果（每 10 分钟 `fetchGitHubReleases` 失败直接 `return err`）
2. 点「升级服务端」时下载地址仍按 GitHub 拼接，最终 404 / 超时

**根因链**（4 处协同）：
1. **抓取失败无 fallback**（根因 A）— `task_check_version.go` 的 `if isGitHub { ... } else { ... }` 硬分支，`fetchGitHubReleases` 失败直接 `return err`，不尝试 CNB
2. **探测对象与真实接口不一致**（根因 B）— `source_selector.go` 探测 `api.github.com` 根域名，而抓取用 `/repos/.../releases`（限流 403 时根域名仍 200）
3. **探测结果粘性缓存 10 分钟 + 非线程安全**（根因 C）— `isGitHub` 无锁、10 分钟才重探，并发 data race
4. **语义扭曲**（根因 D）— `GithubAvailable` 字段被升级流程用来决定下载地址，实际含义是「GitHub 是否可达」，导致「探测说通、下载 404」

## 变更内容

### 1. 重写 `source_selector.go`
- 探测目标从根域名改为真实 release 接口（`/repos/.../releases`）
- `sync.Mutex` 保护 `mode`/`snapshot`，所有公开方法 goroutine-safe
- 新增 `Probe(ctx)` 并行探测两源（HEAD + 3s 超时），返回 `ProbeSnapshot{ok, latencyMs, useGitHub}`
- 阈值选源 `pickSource`：超时即弃；双可达按延迟差倍数（≥2× 且 ≥200ms）切换；都不可达保守默认 GitHub
- 缓存 TTL 5 分钟，过期自动重探

### 2. 改造 `task_check_version.go`
- 抽出 `fetchReleasesWithFallback`：主源失败自动回退备源重试一次
- 两个底层 `http.Client` 加 8s 超时（原无超时）
- `GithubAvailable` 语义改为「实际命中源」，升级下载地址与版本信息来源强一致

### 3. 新增探测接口 `/api/version/probe`
- 路由 `GET /api/version/probe`（需管理员认证）
- 透传 `SourceSelector.Probe()` 结果：两源 `{ok, latencyMs}` + recommended + selectedMode
- 升级流程（`handler_admin_control.go`）：`pullSource == "auto"` 时升级按需 `Probe()`，不依赖后台任务缓存

### 4. 容器层暴露
- `internal/app/app.go`：新增 `SourceSelector()` / `SetPullSourceMode()`
- `internal/app/infra.go`：`initInfra` 初始化 `SourceSelector`

### 5. 文档
- `handler_version.go`：增加 `@Security UserAuthToken` Swagger 注解
- `dto/app_dto.go`：增加 `SourceProbeItem` / `SourceProbeDTO` 的 Swagger `@Description` / `example` 注解
- `dto/note_dto.go`：修复 `NoteHistoryDTO.Diffs` 的 `swaggertype` 注解，消除 swag 生成报错
- 运行 `swag init` 重新生成 `docs/swagger.json` / `docs/swagger.yaml` / `docs/docs.go`
- `docs/REST_API.md`：新增「Probe version source latency」API 文档章节

### 改动文件清单

| 文件 | 改动类型 |
|------|----------|
| `service/pkg/fileurl/source_selector.go` | **重写** — 242 行 |
| `service/pkg/fileurl/source_selector_test.go` | **新增** — 99 行 |
| `service/internal/task/task_check_version.go` | **重写** — 387 行 |
| `service/internal/routers/api_router/handler_version.go` | **重写** — 119 行 |
| `service/internal/routers/router_api.go` | 修改 |
| `service/internal/routers/api_router/handler_admin_control.go` | 修改 |
| `service/internal/app/app.go` | 修改 |
| `service/internal/app/infra.go` | 修改 |
| `service/internal/dto/app_dto.go` | 修改 |
| `service/internal/dto/note_dto.go` | 修改 |
| `service/docs/swagger.json` | **重新生成** |
| `service/docs/swagger.yaml` | **重新生成** |
| `service/docs/docs.go` | **重新生成** |
| `service/docs/REST_API.md` | 修改 |

## 测试
- `go build ./...` — 编译 ✅
- `go vet ./...` — 静态分析 ✅
- `go test -race -count=1 ./...` — 全部测试（含 data race）✅
- `go test -race -run "TestPickSource|TestSourceSelector" ./pkg/fileurl/` — source_selector 专项 ✅
- `pickSource` 表驱动测试覆盖：单边超时 / 双可达低延迟差 / 双可达高延迟差 / 双不可用
- 并发 50 goroutine 同时调用 `IsGitHub`/`Probe`/`Snapshot`/`SetMode` — data race 测试通过
