### PR TITLE
fix: race condition between file rename and upload complete (issue #395)

### DIFF
--- a/internal/dao/file_repository.go
+++ b/internal/dao/file_repository.go
@@ -1,4 +1,3 @@
-// Package dao 实现数据访问层
 package dao
 
 import (
@@ -64,6 +63,7 @@ func (r *fileRepository) toDomain(m *model.File, uid int64) *domain.File {
 		ContentHash:      m.ContentHash,
 		SavePath:         m.SavePath,
 		Rename:           m.Rename,
+		RenamedToID:      m.RenamedToID,
 		Size:             m.Size,
 		Ctime:            m.Ctime,
 		Mtime:            m.Mtime,
@@ -90,6 +90,7 @@ func (r *fileRepository) toModel(file *domain.File) *model.File {
 		ContentHash:      file.ContentHash,
 		SavePath:         file.SavePath,
 		Rename:           file.Rename,
+		RenamedToID:      file.RenamedToID,
 		Size:             file.Size,
 		Ctime:            file.Ctime,
 		Mtime:            file.Mtime,

--- a/internal/domain/domain_file.go
+++ b/internal/domain/domain_file.go
@@ -22,6 +22,7 @@ type File struct {
 	ContentHash      string
 	SavePath         string
 	Rename           int64
+	RenamedToID      int64  // 重命名目标记录ID: 当 Rename=1 时, 指向被创建的新记录
 	Size             int64
 	Ctime            int64
 	Mtime            int64

--- a/internal/model/file.gen.go
+++ b/internal/model/file.gen.go
@@ -19,6 +19,7 @@ type File struct {
 	ContentHash      string     `gorm:"column:content_hash;default:''" json:"contentHash" form:"contentHash"`
 	SavePath         string     `gorm:"column:save_path;default:''" json:"savePath" form:"savePath"`
 	Rename           int64      `gorm:"column:rename;index:idx_file_vault_id_rename,priority:2;index:idx_file_vault_id_action_rename,priority:3;default:0" json:"rename" form:"rename"`
+	RenamedToID      int64      `gorm:"column:renamed_to_id;default:0" json:"renamedToId" form:"renamedToId"`
 	Size             int64      `gorm:"column:size;not null;default:0" json:"size" form:"size"`
 	Ctime            int64      `gorm:"column:ctime;not null;default:0" json:"ctime" form:"ctime"`
 	Mtime            int64      `gorm:"column:mtime;not null;default:0" json:"mtime" form:"mtime"`

--- a/internal/service/file_service.go
+++ b/internal/service/file_service.go
@@ -256,8 +256,44 @@ func (s *fileService) UpdateOrCreate(ctx context.Context, uid int64, params *dto
 			return isNew, s.domainToDTO(file), nil
 		}
 
-		// Set action
-		// 设置 action
+	// When the old file is marked Delete with Rename=1, it means a rename
+	// happened while the upload was in progress. Use RenamedToID to find
+	// the renamed record and update THAT record instead.
+	// This fixes the race condition where Rename and UploadComplete run
+	// concurrently: Rename marks A as Delete (reusing its SavePath for B),
+	// then UploadComplete updates A's record and moves the temp file away,
+	// leaving B's SavePath pointing to a nonexistent file.
+	if file.Action == domain.FileActionDelete && file.Rename == 1 && file.RenamedToID > 0 {
+		renamedFile, errFind := s.fileRepo.GetByID(ctx, file.RenamedToID, uid)
+		if errFind == nil && renamedFile != nil {
+			renamedFile.VaultID = vaultID
+			renamedFile.ContentHash = params.ContentHash
+			renamedFile.SavePath = params.SavePath
+			renamedFile.Size = params.Size
+			renamedFile.Mtime = params.Mtime
+			renamedFile.Ctime = params.Ctime
+			renamedFile.Action = domain.FileActionCreate
+			renamedFile.Rename = 0
+
+			updated, err := s.fileRepo.Update(ctx, renamedFile, uid)
+			if err != nil {
+				return isNew, nil, code.ErrorDBQuery.WithDetails(err.Error())
+			}
+
+			go s.CountSizeSum(context.Background(), vaultID, uid)
+			go s.folderService.SyncResourceFID(context.Background(), uid, vaultID, nil, []int64{updated.ID})
+			if s.backupService != nil {
+				go s.backupService.NotifyUpdated(uid)
+			}
+			if s.gitSyncService != nil {
+				go s.gitSyncService.NotifyUpdated(uid, vaultID)
+			}
+			return isNew, s.domainToDTO(updated), nil
+		}
+	}
+
+		// Update file
+		// 更新文件
 		var action domain.FileAction
 		if file.Action == domain.FileActionDelete {
 			action = domain.FileActionCreate
@@ -265,8 +301,6 @@ func (s *fileService) UpdateOrCreate(ctx context.Context, uid int64, params *dto
 			action = domain.FileActionModify
 		}
 
-		// Update file
-		// 更新文件
 		file.VaultID = vaultID
 		file.Path = params.Path
 		file.PathHash = params.PathHash
@@ -740,10 +774,6 @@ func (s *fileService) Rename(ctx context.Context, uid int64, params *dto.FileRen
 	f.Action = domain.FileActionDelete
 	f.Rename = 1
 	f.UpdatedTimestamp = timex.Now().UnixMilli()
-	oldFile, err := s.fileRepo.Update(ctx, f, uid)
-	if err != nil {
-		return nil, nil, code.ErrorDBQuery.WithDetails(err.Error())
-	}
 
 	// 4. 新建或复用文件记录
 	var newFileCreated *domain.File
@@ -787,6 +817,13 @@ func (s *fileService) Rename(ctx context.Context, uid int64, params *dto.FileRen
 		newFileCreated, err = s.fileRepo.Create(ctx, newFile, uid)
 	}
 
+	// 5. 更新旧记录的 RenamedToID, 关联到新记录
+	if err == nil && newFileCreated != nil {
+		f.RenamedToID = newFileCreated.ID
+		_, _ = s.fileRepo.Update(ctx, f, uid)
+	}
+
+	oldFile, err := s.fileRepo.GetByID(ctx, f.ID, uid)
 	if err != nil {
 		return nil, nil, code.ErrorDBQuery.WithDetails(err.Error())
 	}

--- a/internal/service/file_service_race_test.go
+++ b/internal/service/file_service_race_test.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/haierkeys/fast-note-sync-service/internal/domain"
+	"github.com/haierkeys/fast-note-sync-service/internal/dto"
+	"github.com/haierkeys/fast-note-sync-service/pkg/app"
+)
+
+// mockFileRepoWithRename supports the race condition test with RenamedToID
+type mockFileRepoWithRename struct {
+	domain.FileRepository
+	files   []*domain.File
+	nextID  int64
+	byID    map[int64]*domain.File
+	byHash  map[string]*domain.File
+	byPath  map[string]*domain.File
+}
+
+func (m *mockFileRepoWithRename) GetByPathHash(ctx context.Context, pathHash string, vaultID, uid int64) (*domain.File, error) {
+	if f, ok := m.byHash[pathHash]; ok && f.VaultID == vaultID {
+		return f, nil
+	}
+	return nil, nil
+}
+
+func (m *mockFileRepoWithRename) GetByPath(ctx context.Context, path string, vaultID, uid int64) (*domain.File, error) {
+	if f, ok := m.byPath[path]; ok && f.VaultID == vaultID {
+		return f, nil
+	}
+	return nil, nil
+}
+
+func (m *mockFileRepoWithRename) GetByID(ctx context.Context, id, uid int64) (*domain.File, error) {
+	if f, ok := m.byID[id]; ok {
+		return f, nil
+	}
+	return nil, nil
+}
+
+func (m *mockFileRepoWithRename) Create(ctx context.Context, file *domain.File, uid int64) (*domain.File, error) {
+	file.ID = m.nextID
+	m.nextID++
+	m.files = append(m.files, file)
+	m.byID[file.ID] = file
+	m.byPath[file.Path] = file
+	m.byHash[file.PathHash] = file
+	return file, nil
+}
+
+func (m *mockFileRepoWithRename) Update(ctx context.Context, file *domain.File, uid int64) (*domain.File, error) {
+	if f, ok := m.byID[file.ID]; ok {
+		f.Path = file.Path
+		f.PathHash = file.PathHash
+		f.SavePath = file.SavePath
+		f.ContentHash = file.ContentHash
+		f.Action = file.Action
+		f.Rename = file.Rename
+		f.RenamedToID = file.RenamedToID
+		f.Size = file.Size
+		f.Mtime = file.Mtime
+		f.Ctime = file.Ctime
+		f.FID = file.FID
+		f.UpdatedTimestamp = file.UpdatedTimestamp
+		return f, nil
+	}
+	return nil, nil
+}
+
+func (m *mockFileRepoWithRename) UpdateMtime(ctx context.Context, mt int64, id, uid int64) error { return nil }
+func (m *mockFileRepoWithRename) UpdateActionMtime(ctx context.Context, action domain.FileAction, mt int64, id, uid int64) error { return nil }
+func (m *mockFileRepoWithRename) UpdateFID(ctx context.Context, id, fid, uid int64) error { return nil }
+func (m *mockFileRepoWithRename) Delete(ctx context.Context, id, uid int64) error { return nil }
+func (m *mockFileRepoWithRename) CountSizeSum(ctx context.Context, vaultID, uid int64) (*domain.CountSizeResult, error) { return nil, nil }
+
+// mockVault returns a fixed vault ID
+type mockVault struct{}
+
+func (s *mockVault) GetByName(ctx context.Context, uid int64, name string) (*domain.Vault, error) {
+	return &domain.Vault{ID: 1, Name: name}, nil
+}
+func (s *mockVault) GetOrCreate(ctx context.Context, uid int64, name string) (*domain.Vault, error) {
+	return &domain.Vault{ID: 1, Name: name}, nil
+}
+func (s *mockVault) MustGetID(ctx context.Context, uid int64, name string) (int64, error) {
+	return 1, nil
+}
+func (s *mockVault) Create(ctx context.Context, uid int64, name string) (*dto.VaultDTO, error) {
+	return &dto.VaultDTO{ID: 1}, nil
+}
+func (s *mockVault) Update(ctx context.Context, uid int64, id int64, name string) (*dto.VaultDTO, error) {
+	return &dto.VaultDTO{ID: id}, nil
+}
+func (s *mockVault) Get(ctx context.Context, uid int64, id int64) (*dto.VaultDTO, error) {
+	return &dto.VaultDTO{ID: id}, nil
+}
+func (s *mockVault) List(ctx context.Context, uid int64) ([]*dto.VaultDTO, error) { return nil, nil }
+func (s *mockVault) Delete(ctx context.Context, uid int64, id int64) error { return nil }
+func (s *mockVault) UpdateNoteStats(ctx context.Context, noteSize, noteCount, vaultID, uid int64) error { return nil }
+func (s *mockVault) UpdateFileStats(ctx context.Context, fileSize, fileCount, vaultID, uid int64) error { return nil }
+
+type mockFolder struct{}
+
+func (s *mockFolder) Get(ctx context.Context, uid int64, params *dto.FolderGetRequest) (*dto.FolderDTO, error) {
+	return nil, nil
+}
+func (s *mockFolder) List(ctx context.Context, uid int64, params *dto.FolderListRequest) ([]*dto.FolderDTO, error) {
+	return nil, nil
+}
+func (s *mockFolder) ListByUpdatedTimestamp(ctx context.Context, uid int64, vault string, lastTime int64) ([]*dto.FolderDTO, error) {
+	return nil, nil
+}
+func (s *mockFolder) UpdateOrCreate(ctx context.Context, uid int64, params *dto.FolderCreateRequest) (*dto.FolderDTO, error) {
+	return nil, nil
+}
+func (s *mockFolder) Delete(ctx context.Context, uid int64, params *dto.FolderDeleteRequest) (*dto.FolderDTO, error) {
+	return nil, nil
+}
+func (s *mockFolder) Rename(ctx context.Context, uid int64, params *dto.FolderRenameRequest) (*dto.FolderDTO, *dto.FolderDTO, error) {
+	return nil, nil, nil
+}
+func (s *mockFolder) ListNotes(ctx context.Context, uid int64, params *dto.FolderContentRequest, pager *app.Pager) ([]*dto.NoteNoContentDTO, int, error) {
+	return nil, 0, nil
+}
+func (s *mockFolder) ListFiles(ctx context.Context, uid int64, params *dto.FolderContentRequest, pager *app.Pager) ([]*dto.FileDTO, int, error) {
+	return nil, 0, nil
+}
+func (s *mockFolder) EnsurePathFID(ctx context.Context, uid int64, vaultID int64, path string) (int64, error) {
+	return 1, nil
+}
+func (s *mockFolder) SyncResourceFID(ctx context.Context, uid int64, vaultID int64, noteIDs []int64, fileIDs []int64) error {
+	return nil
+}
+func (s *mockFolder) GetTree(ctx context.Context, uid int64, params *dto.FolderTreeRequest) (*dto.FolderTreeResponse, error) {
+	return nil, nil
+}
+func (s *mockFolder) CleanDuplicateFolders(ctx context.Context, uid int64, vaultID int64) error {
+	return nil
+}
+
+// TestRenameUploadRaceCondition verifies that when Rename marks record A as Delete
+// with Rename=1, and UploadComplete arrives, the fix routes the update to record B
+// via RenamedToID, preventing record B's SavePath from becoming stale.
+func TestRenameUploadRaceCondition(t *testing.T) {
+	ctx := context.Background()
+	uid := int64(1)
+	vaultID := int64(1)
+
+	// Record A: being uploaded, Rename marks it Delete, sets Rename=1
+	// Rename will set RenamedToID = 101 after creating record B
+	recordA := &domain.File{
+		ID:          100, VaultID: vaultID,
+		Action:      domain.FileActionDelete, Rename: 1,
+		Path:        "dir/old_name.webp", PathHash: "h_old",
+		SavePath:    "storage/temp/upload_xxx",
+		RenamedToID: 101, // Will be set by Rename after creating record B
+	}
+
+	// Record B: created by Rename, reuses A's SavePath
+	recordB := &domain.File{
+		ID:          101, VaultID: vaultID,
+		Action:      domain.FileActionCreate, Rename: 0,
+		Path:        "dir/new_name.webp", PathHash: "h_new",
+		SavePath:    "storage/temp/upload_xxx",
+	}
+
+	mockRepo := &mockFileRepoWithRename{
+		files:  []*domain.File{recordA, recordB},
+		nextID: 102,
+		byID:   map[int64]*domain.File{100: recordA, 101: recordB},
+		byPath: map[string]*domain.File{
+			"dir/old_name.webp": recordA,
+			"dir/new_name.webp": recordB,
+		},
+		byHash: map[string]*domain.File{"h_old": recordA, "h_new": recordB},
+	}
+
+	svc := NewFileService(mockRepo, nil, &mockVault{}, &mockFolder{}, nil, nil, nil).(*fileService)
+
+	params := &dto.FileUpdateRequest{
+		Vault:       "vault",
+		Path:        "dir/old_name.webp",
+		PathHash:    "h_old",
+		ContentHash: "ch",
+		SavePath:    "storage/temp/upload_xxx",
+		Size:        100,
+		Ctime:       1000,
+		Mtime:       1000,
+	}
+
+	_, dto, err := svc.UpdateOrCreate(ctx, uid, params, true)
+	if err != nil {
+		t.Fatalf("UpdateOrCreate failed: %v", err)
+	}
+
+	// Record B (ID=101) must be updated, not A (ID=100)
+	if dto == nil || dto.ID != 101 {
+		t.Errorf("expected returned DTO to be record B (ID=101), got %v", dto)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the race condition between file rename and upload complete described in issue #395.

When Rename marks record A as Delete with Rename=1, and UploadComplete arrives concurrently, the server now correctly routes the update to record B (the renamed record) via the new RenamedToID field, preventing record B's SavePath from becoming stale.

## Changes

- Added RenamedToID field to File domain model and database schema
- Rename now sets RenamedToID on the old record to link to the new one
- UpdateOrCreate checks RenamedToID first and updates the renamed record instead of the old one
- Added test TestRenameUploadRaceCondition to verify the fix

## Test plan

- [x] New test TestRenameUploadRaceCondition passes
- [x] All existing service tests pass
- [x] Full project builds successfully