### PR TITLE
fix(backup): 752GB storage leak — staging in container /tmp + retention_days default 0

### DIFF
--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -68,7 +68,7 @@ func initServices(cfg *AppConfig, infra *Infra, repos *Repositories, logger *zap
 		logger,
 	)
 	s.StorageService = service.NewStorageService(repos.StorageRepo, &cfg.Storage)
-	s.BackupService = service.NewBackupService(repos.BackupRepo, repos.NoteRepo, repos.FolderRepo, repos.FileRepo, repos.VaultRepo, s.StorageService, &cfg.Storage, logger)
+	s.BackupService = service.NewBackupService(repos.BackupRepo, repos.NoteRepo, repos.FolderRepo, repos.FileRepo, repos.VaultRepo, s.StorageService, &cfg.Storage, cfg.App.TempPath, logger)
 	s.GitSyncService = service.NewGitSyncService(repos.GitSyncRepo, repos.NoteRepo, repos.FolderRepo, repos.FileRepo, repos.VaultRepo, repos.SettingRepo, &cfg.Git, logger)
 
 	// Initialize SyncLogService first, as NoteService/FileService/SettingService depend on it

--- a/internal/model/backup_config.gen.go
+++ b/internal/model/backup_config.gen.go
@@ -14,24 +14,26 @@ const TableNameBackupConfig = "backup_config"
 
 // BackupConfig mapped from table <backup_config>
 type BackupConfig struct {
-	ID               int64      `gorm:"column:id;primaryKey" json:"id" form:"id"`
-	UID              int64      `gorm:"column:uid;not null;index:idx_backup_config_uid,priority:1;default:0" json:"uid" form:"uid"`
-	VaultID          int64      `gorm:"column:vault_id;not null;default:0" json:"vaultId" form:"vaultId"`
-	Type             string     `gorm:"column:type;default:''" json:"type" form:"type"`
-	StorageIds       string     `gorm:"column:storage_ids;type:TEXT;default:''" json:"storageIds" form:"storageIds"`
-	IsEnabled        int64      `gorm:"column:is_enabled;default:0" json:"isEnabled" form:"isEnabled"`
-	CronStrategy     string     `gorm:"column:cron_strategy;default:''" json:"cronStrategy" form:"cronStrategy"`
-	CronExpression   string     `gorm:"column:cron_expression;type:TEXT;default:''" json:"cronExpression" form:"cronExpression"`
-	IncludeVaultName int64      `gorm:"column:include_vault_name;default:0" json:"includeVaultName" form:"includeVaultName"`
-	RetentionDays    int64      `gorm:"column:retention_days;default:0" json:"retentionDays" form:"retentionDays"`
-	LastRunTime      time.Time  `gorm:"column:last_run_time" json:"lastRunTime" form:"lastRunTime"`
-	NextRunTime      time.Time  `gorm:"column:next_run_time;index:idx_backup_config_next_run_time,priority:1" json:"nextRunTime" form:"nextRunTime"`
-	LastStatus       int64      `gorm:"column:last_status;default:0" json:"lastStatus" form:"lastStatus"`
-	LastMessage      string     `gorm:"column:last_message;type:TEXT;default:''" json:"lastMessage" form:"lastMessage"`
-	PasswordMode     int64      `gorm:"column:password_mode;default:0" json:"passwordMode" form:"passwordMode"`
-	PasswordValue    string     `gorm:"column:password_value;type:TEXT;default:''" json:"passwordValue" form:"passwordValue"`
-	CreatedAt        timex.Time `gorm:"column:created_at;default:NULL;autoCreateTime:false" json:"createdAt" form:"createdAt"`
-	UpdatedAt        timex.Time `gorm:"column:updated_at;default:NULL;autoUpdateTime:false" json:"updatedAt" form:"updatedAt"`
+	ID               int64  `gorm:"column:id;primaryKey" json:"id" form:"id"`
+	UID              int64  `gorm:"column:uid;not null;index:idx_backup_config_uid,priority:1;default:0" json:"uid" form:"uid"`
+	VaultID          int64  `gorm:"column:vault_id;not null;default:0" json:"vaultId" form:"vaultId"`
+	Type             string `gorm:"column:type;default:''" json:"type" form:"type"`
+	StorageIds       string `gorm:"column:storage_ids;type:TEXT;default:''" json:"storageIds" form:"storageIds"`
+	IsEnabled        int64  `gorm:"column:is_enabled;default:0" json:"isEnabled" form:"isEnabled"`
+	CronStrategy     string `gorm:"column:cron_strategy;default:''" json:"cronStrategy" form:"cronStrategy"`
+	CronExpression   string `gorm:"column:cron_expression;type:TEXT;default:''" json:"cronExpression" form:"cronExpression"`
+	IncludeVaultName int64  `gorm:"column:include_vault_name;default:0" json:"includeVaultName" form:"includeVaultName"`
+	// RetentionDays default must stay in sync with the gorm-gen source / scripts/db.sql, which specify 10.
+	// RetentionDays 的默认值需与 gorm-gen 源定义及 scripts/db.sql 保持一致，两者均为 10。
+	RetentionDays int64      `gorm:"column:retention_days;default:10" json:"retentionDays" form:"retentionDays"`
+	LastRunTime   time.Time  `gorm:"column:last_run_time" json:"lastRunTime" form:"lastRunTime"`
+	NextRunTime   time.Time  `gorm:"column:next_run_time;index:idx_backup_config_next_run_time,priority:1" json:"nextRunTime" form:"nextRunTime"`
+	LastStatus    int64      `gorm:"column:last_status;default:0" json:"lastStatus" form:"lastStatus"`
+	LastMessage   string     `gorm:"column:last_message;type:TEXT;default:''" json:"lastMessage" form:"lastMessage"`
+	PasswordMode  int64      `gorm:"column:password_mode;default:0" json:"passwordMode" form:"passwordMode"`
+	PasswordValue string     `gorm:"column:password_value;type:TEXT;default:''" json:"passwordValue" form:"passwordValue"`
+	CreatedAt     timex.Time `gorm:"column:created_at;default:NULL;autoCreateTime:false" json:"createdAt" form:"createdAt"`
+	UpdatedAt     timex.Time `gorm:"column:updated_at;default:NULL;autoUpdateTime:false" json:"updatedAt" form:"updatedAt"`
 }
 
 // TableName BackupConfig's table name

--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -27,6 +27,13 @@ import (
 
 var errNoUpdates = errors.New("no updates found")
 
+// DefaultRetentionDays is the fallback retention period (in days) applied when a
+// config's RetentionDays is left at 0. Must match the design intent in scripts/db.sql
+// and the gorm default on model.BackupConfig.RetentionDays.
+// DefaultRetentionDays 是当配置的 RetentionDays 为 0 时应用的默认保留天数，
+// 需与 scripts/db.sql 的设计意图及 model.BackupConfig.RetentionDays 的 gorm 默认值保持一致。
+const DefaultRetentionDays = 10
+
 // BackupService defines the business service interface for Backup
 // 定义备份业务服务接口
 type BackupService interface {
@@ -48,6 +55,7 @@ type backupService struct {
 	vaultRepo      domain.VaultRepository
 	storageService StorageService
 	storageConfig  *config.StorageConfig
+	tempPath       string
 	logger         *zap.Logger
 	syncTimers     map[int64]*time.Timer
 	timerMu        sync.Mutex
@@ -69,10 +77,14 @@ func NewBackupService(
 	vaultRepo domain.VaultRepository,
 	storageService StorageService,
 	storageConfig *config.StorageConfig,
+	tempPath string,
 	logger *zap.Logger,
 ) BackupService {
+	if tempPath == "" {
+		tempPath = "storage/temp"
+	}
 	ctx, cancel := context.WithCancel(context.Background())
-	return &backupService{
+	s := &backupService{
 		backupRepo:     backupRepo,
 		noteRepo:       noteRepo,
 		folderRepo:     folderRepo,
@@ -80,12 +92,38 @@ func NewBackupService(
 		vaultRepo:      vaultRepo,
 		storageService: storageService,
 		storageConfig:  storageConfig,
+		tempPath:       tempPath,
 		logger:         logger,
 		syncTimers:     make(map[int64]*time.Timer),
 		runningTasks:   make(map[int64]context.CancelFunc),
 		ctx:            ctx,
 		cancel:         cancel,
 	}
+
+	// Startup sweep: reclaim orphaned backup staging files left behind by a
+	// previously killed/OOM'd process (per-run defers don't run in that case).
+	// No backup can be in-flight at service construction time, so a full wipe is safe.
+	// 启动清理：回收上次进程被杀/OOM 后残留的备份暂存文件（该场景下 per-run defer 不会执行）。
+	// 服务构造时不可能有正在进行的备份，因此可以安全地整体清空。
+	stagingDir := s.backupStagingDir()
+	if err := os.RemoveAll(stagingDir); err != nil && logger != nil {
+		logger.Warn("Failed to sweep stale backup staging dir", zap.String("dir", stagingDir), zap.Error(err))
+	}
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil && logger != nil {
+		logger.Warn("Failed to recreate backup staging dir", zap.String("dir", stagingDir), zap.Error(err))
+	}
+
+	return s
+}
+
+// backupStagingDir returns the directory used to stage in-progress backup
+// working dirs and zip files. Under the app's configured temp path (not the
+// container's /tmp) so it can be swept on startup and doesn't leak into the
+// persistent docker overlay layer.
+// backupStagingDir 返回用于暂存备份工作目录和 zip 文件的目录。位于应用配置的临时路径下
+// （而非容器的 /tmp），可在启动时清理，不会泄漏进 docker 持久化的 overlay 层。
+func (s *backupService) backupStagingDir() string {
+	return filepath.Join(s.tempPath, "backup")
 }
 
 // GetConfigs Get user's backup configurations
@@ -128,6 +166,14 @@ func (s *backupService) UpdateConfig(ctx context.Context, uid int64, req *dto.Ba
 		}
 	}
 
+	// A RetentionDays of 0 means "no explicit value provided"; fall back to the
+	// design-intended default rather than silently keeping backups forever.
+	// RetentionDays 为 0 表示"未显式设置"，回退到设计预期的默认值，而不是静默地永久保留备份。
+	retentionDays := req.RetentionDays
+	if retentionDays == 0 {
+		retentionDays = DefaultRetentionDays
+	}
+
 	config := &domain.BackupConfig{
 		ID:               req.ID,
 		UID:              uid,
@@ -138,7 +184,7 @@ func (s *backupService) UpdateConfig(ctx context.Context, uid int64, req *dto.Ba
 		CronStrategy:     req.CronStrategy,
 		CronExpression:   req.CronExpression,
 		IncludeVaultName: req.IncludeVaultName,
-		RetentionDays:    req.RetentionDays,
+		RetentionDays:    retentionDays,
 		PasswordMode:     req.PasswordMode,
 		PasswordValue:    req.PasswordValue,
 	}
@@ -454,7 +500,10 @@ func (s *backupService) handleBackupSync(ctx context.Context, config *domain.Bac
 
 	// 3. Prepare temporary working directory
 	// 3. 准备临时工作目录
-	tempDir, err := os.MkdirTemp("", fmt.Sprintf("backup_%d_", uid))
+	if err := os.MkdirAll(s.backupStagingDir(), 0o755); err != nil {
+		return s.finishTask(taskCtx, config, err, 0, 0, startTime)
+	}
+	tempDir, err := os.MkdirTemp(s.backupStagingDir(), fmt.Sprintf("backup_%d_", uid))
 	if err != nil {
 		return s.finishTask(taskCtx, config, err, 0, 0, startTime)
 	}
@@ -502,7 +551,10 @@ func (s *backupService) runArchive(ctx context.Context, config *domain.BackupCon
 	uid := config.UID
 	vaultName := s.getVaultName(ctx, config.VaultID, uid)
 	zipName := fmt.Sprintf("backup_%s_%d_%s_%s.zip", config.Type, uid, vaultName, startTime.Format("20060102_150405"))
-	zipPath := filepath.Join(os.TempDir(), zipName)
+	if err := os.MkdirAll(s.backupStagingDir(), 0o755); err != nil {
+		return 0, 0, err
+	}
+	zipPath := filepath.Join(s.backupStagingDir(), zipName)
 
 	defer os.Remove(zipPath)
 

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -69,6 +69,7 @@ func NewMigrationManager(db *gorm.DB, logger *zap.Logger, version string, cfg, u
 		migrations: []Migration{
 			&NoteHistoryRenameMigrate{},
 			&UserEmailLowercaseMigrate{},
+			&BackupRetentionDefaultMigrate{},
 		},
 	}
 }

--- a/internal/upgrade/upgrade_backup_retention_default.go
+++ b/internal/upgrade/upgrade_backup_retention_default.go
@@ -1,0 +1,39 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// BackupRetentionDefaultMigrate backfills existing backup_config rows whose
+// retention_days is still 0 (the old runtime default) to 10, matching the
+// design intent in scripts/db.sql. RetentionDays == 0 was treated as "keep
+// forever" by finishTask, causing unbounded backup history/storage growth.
+// BackupRetentionDefaultMigrate 将 retention_days 仍为 0（旧的运行时默认值）的
+// backup_config 记录回填为 10，与 scripts/db.sql 的设计意图保持一致。
+// RetentionDays == 0 曾被 finishTask 视为"永久保留"，导致备份历史/存储无限增长。
+type BackupRetentionDefaultMigrate struct{}
+
+// Version returns the migration version
+// Version 返回升级版本号
+func (m *BackupRetentionDefaultMigrate) Version() string {
+	return "3.5.2"
+}
+
+// Description returns the migration description
+// Description 返回升级描述
+func (m *BackupRetentionDefaultMigrate) Description() string {
+	return "Backfill backup_config.retention_days from 0 to 10 (design default)"
+}
+
+// Up runs the migration
+// Up 执行升级操作
+func (m *BackupRetentionDefaultMigrate) Up(db *gorm.DB, ctx context.Context, mc *MigrationContext) error {
+	err := db.WithContext(ctx).Table("backup_config").Where("retention_days = 0").Update("retention_days", 10).Error
+	if err != nil {
+		return fmt.Errorf("failed to backfill backup_config retention_days: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem / 问题

The cloud-storage backup feature leaks disk unboundedly. In one real deployment it grew to **752 GB** of orphaned files inside the container. Two independent root causes:

云存储备份会无界占用磁盘。某真实部署中在容器内堆积到 **752 GB** 孤儿文件。两个独立根因：

### Bug 1 — backup staging leaks into container `/tmp`

`handleBackupSync` and `runArchive` stage the working dir and the zip via `os.MkdirTemp("", ...)` / `os.TempDir()`, i.e. `/tmp` — which lives in the **persistent docker overlay2 layer**, not a tmpfs. They are cleaned only by per-run `defer`s, which are **skipped when the process is killed / OOM-ed / restarted mid-backup** (each zip is ~2.5 GB, and incremental runs frequently). Orphaned `backup_*` dirs and `backup_*.zip` files then accumulate forever. There is no janitor for `os.TempDir()` (the existing temp-clean task only sweeps the configurable `storage/temp`).

备份的工作目录和 zip 经 `os.TempDir()` 落在容器 `/tmp`（overlay2 持久层），只靠 per-run `defer` 清理；进程被 kill/OOM/重启时 defer 不执行，孤儿文件永久堆积，且无任何后台清扫覆盖 `os.TempDir()`。

### Bug 2 — `retention_days` default is 0 (= keep forever), contradicting design intent

`scripts/db.sql` documents a **10-day** retention default, but the runtime GORM model defaults `retention_days` to **0**, and `finishTask` treats `0` as "keep forever" (`if config.RetentionDays != 0`). So unless a user manually sets retention, backup history/files are **never pruned** → unbounded growth even when staging is fixed.

`scripts/db.sql` 意图保留 10 天，但运行时 GORM 模型默认 `retention_days=0`，而 `finishTask` 把 0 当作"永久保留"，导致默认永不清理。

## Fix / 修复

**Bug 1** (`internal/service/backup_service.go`, `internal/app/services.go`):
- Stage backups under the configurable `App.TempPath` (`<temp-path>/backup`, default `storage/temp/backup`) instead of `os.TempDir()` — a location that can be bind-mounted and is not the container's persistent overlay `/tmp`.
- Add a **startup sweep** in `NewBackupService`: no backup can be in-flight at construction time, so orphans left by a previously killed process are safely wiped and the dir recreated. Per-run `defer` cleanups are kept.

**Bug 2** (`internal/service/backup_service.go`, `internal/model/backup_config.gen.go`, `internal/upgrade/`):
- Model default `retention_days` `0 → 10` (aligns runtime with `scripts/db.sql`).
- `UpdateConfig` falls back to a new `DefaultRetentionDays = 10` const when the submitted value is `0`. (`-1` = "keep only current" is unaffected.)
- New versioned migration `3.5.2` (`BackupRetentionDefaultMigrate`) backfills existing rows: `UPDATE backup_config SET retention_days = 10 WHERE retention_days = 0`, so already-deployed instances stop leaking.

`sync`/mirror mode is unaffected (it never produced history files and was already correct).

## Testing / 验证
```
go build ./...            # clean
go test ./internal/service/... ./internal/upgrade/...   # ok
go vet  ./internal/service/... ./internal/upgrade/...   # clean
```
