### PR TITLE
fix(api): allow authenticated REST clients to list vaults

### DIFF
--- a/internal/middleware/user_auth_token.go
+++ b/internal/middleware/user_auth_token.go
@@ -104,10 +104,11 @@ func AuthenticateUserToken(c *gin.Context, secretKey string, tokenService servic
 
 	path := c.Request.URL.Path
 	method := c.Request.Method
+	isRead := method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var function string
 
 	var resource string
-	if strings.HasPrefix(path, "/api/note") || strings.HasPrefix(path, "/api/folder") {
+	if (path == "/api/vault" && isRead) || strings.HasPrefix(path, "/api/note") || strings.HasPrefix(path, "/api/folder") {
 		resource = "note"
 	} else if strings.HasPrefix(path, "/api/file") || strings.HasPrefix(path, "/api/storage") {
 		resource = "file"
@@ -116,7 +117,7 @@ func AuthenticateUserToken(c *gin.Context, secretKey string, tokenService servic
 	}
 
 	if resource != "" {
-		if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
+		if isRead {
 			function = resource + "_r"
 		} else {
 			function = resource + "_w"

--- a/internal/middleware/user_auth_token_test.go
+++ b/internal/middleware/user_auth_token_test.go
@@ -74,6 +74,10 @@ func (s *fakeMiddlewareTokenService) GetRecentClients(ctx context.Context, uid i
 	return nil, nil
 }
 
+func (s *fakeMiddlewareTokenService) CleanExpired(ctx context.Context, uid int64, issueType int) error {
+	return nil
+}
+
 func newMiddlewareJWT(t *testing.T, secretKey, nonce string) string {
 	t.Helper()
 	tokenManager := app.NewTokenManager(app.TokenConfig{
@@ -105,6 +109,9 @@ func runUserAuthMiddlewareWithRequest(t *testing.T, tokenService *fakeMiddleware
 		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
 	})
 	router.POST("/api/file", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
+	})
+	router.GET("/api/vault", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"code": code.Success.Code(), "status": true})
 	})
 
@@ -187,6 +194,40 @@ func TestUserAuthTokenWithConfig_RejectsScopeRestrictedToken(t *testing.T) {
 
 	assert.Equal(t, code.ErrorAuthTokenScopeRestricted.Code(), res.Code)
 	assert.Contains(t, res.Details, "Permission denied")
+}
+
+func TestUserAuthTokenWithConfig_AllowsVaultListWithNoteReadScope(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddlewareWithRequest(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:rest c:ObsidianPlugin f:note_r",
+		IssueType:   2,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token, http.MethodGet, "/api/vault", func(req *http.Request) {
+		req.Header.Set("x-client", "ObsidianPlugin")
+	})
+
+	assert.Equal(t, code.Success.Code(), res.Code)
+}
+
+func TestUserAuthTokenWithConfig_RejectsVaultListWithoutNoteReadScope(t *testing.T) {
+	token := newMiddlewareJWT(t, "test-secret", "nonce-ok")
+	res := runUserAuthMiddlewareWithRequest(t, &fakeMiddlewareTokenService{activeToken: &domain.AuthToken{
+		ID:          2,
+		UID:         1,
+		TokenString: "nonce-ok",
+		Status:      1,
+		Scope:       "p:rest c:ObsidianPlugin f:file_r",
+		IssueType:   2,
+		ExpiredAt:   time.Now().Add(time.Hour),
+	}}, token, http.MethodGet, "/api/vault", func(req *http.Request) {
+		req.Header.Set("x-client", "ObsidianPlugin")
+	})
+
+	assert.Equal(t, code.ErrorAuthTokenScopeRestricted.Code(), res.Code)
 }
 
 func TestUserAuthTokenWithConfig_AllowsLoginTokenWithoutClientHeader(t *testing.T) {

--- a/internal/routers/api_router/handler_vault_test.go
+++ b/internal/routers/api_router/handler_vault_test.go
@@ -106,6 +106,33 @@ func TestVaultHandler_List_Success(t *testing.T) {
 	mockSvc.AssertExpectations(t)
 }
 
+// TestVaultHandler_List_FiltersRestrictedVaults verifies token vault restrictions.
+// TestVaultHandler_List_FiltersRestrictedVaults 验证令牌的 Vault 限制会过滤列表。
+func TestVaultHandler_List_FiltersRestrictedVaults(t *testing.T) {
+	mockSvc := new(svcmocks.MockVaultService)
+	mockSvc.On("List", mock.Anything, int64(1)).
+		Return([]*dto.VaultDTO{
+			{ID: 1, Name: "Vault-A"},
+			{ID: 2, Name: "Vault-B"},
+		}, nil)
+
+	handler := newVaultHandler(mockSvc)
+	c, w := newVaultTestContext("GET", "/api/vault", "", 1)
+	c.Set("vaults", "Vault-B")
+	handler.List(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	result := decodeRes(t, w)
+	data, ok := result["data"].([]interface{})
+	assert.True(t, ok)
+	if assert.Len(t, data, 1) {
+		vault, vaultOK := data[0].(map[string]interface{})
+		assert.True(t, vaultOK)
+		assert.Equal(t, "Vault-B", vault["vault"])
+	}
+	mockSvc.AssertExpectations(t)
+}
+
 // TestVaultHandler_List_NoUID verifies that missing UID returns auth error.
 // TestVaultHandler_List_NoUID 验证未携带 UID 时返回认证错误。
 func TestVaultHandler_List_NoUID(t *testing.T) {
@@ -285,4 +312,3 @@ func TestVaultHandler_RebuildIndex_NoUID(t *testing.T) {
 	assertResponseCode(t, w, code.ErrorNotUserAuthToken.Code())
 	mockSvc.AssertExpectations(t)
 }
-

--- a/internal/routers/router_api.go
+++ b/internal/routers/router_api.go
@@ -169,6 +169,10 @@ func registerAPIRoutes(r *gin.Engine, appContainer *app.App, wss *pkgapp.Websock
 			auth.POST("/setting/rename", settingHandler.Rename)
 			auth.GET("/settings", settingHandler.List)
 
+			// Vault discovery is required before REST clients can address note,
+			// file, and folder APIs. Mutating vault operations remain WebGUI-only.
+			auth.GET("/vault", vaultHandler.List)
+
 			// WebGUI restricted routes
 			// 仅限 WebGUI 访问的路由组
 			webguiGroup := auth.Group("")
@@ -180,7 +184,6 @@ func registerAPIRoutes(r *gin.Engine, appContainer *app.App, wss *pkgapp.Websock
 
 				// Vault management routes
 				// 笔记库管理接口
-				webguiGroup.GET("/vault", vaultHandler.List)
 				webguiGroup.POST("/vault", vaultHandler.CreateOrUpdate)
 				webguiGroup.DELETE("/vault", vaultHandler.Delete)
 				webguiGroup.POST("/vault/rebuild-index", vaultHandler.RebuildIndex)


### PR DESCRIPTION
## Problem

`GET /api/vault` is currently registered inside the `RequireWebGUI()` route group. As a result, a valid manual API token is rejected with `Manual API tokens are not allowed to access WebGUI-only endpoints`.

REST clients need to discover a vault name before they can call the note, file, and folder APIs. The MCP API already supports the equivalent operation through `vault_list`, so the current REST restriction creates an unnecessary capability mismatch between the two authenticated interfaces.

## Solution

- Move only `GET /api/vault` into the normal authenticated route group.
- Classify this endpoint as `note_r`, matching the permission required by MCP `vault_list`.
- Keep filtering the response through the token vault allowlist.
- Keep `POST /api/vault`, `DELETE /api/vault`, index rebuild, and force-delete operations inside the WebGUI-only route group.

## Security properties

The endpoint still requires a valid user authentication token. A token must allow the REST protocol, match the request client, and include `note_r`. Tokens scoped only for unrelated functions such as `file_r` are rejected. Returned vaults remain user-scoped and are filtered by the token vault allowlist.

## Tests

Added coverage for:

- allowing vault discovery with `note_r`;
- rejecting vault discovery with an unrelated function scope;
- filtering vault discovery by the token vault allowlist.

Full test suite:

```text
go test -count=1 ./...
```

All tests pass.