### PR TITLE
fix(mcp): allow trusted loopback proxy deployments

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,13 @@ server:
   # SSE 保活心跳间隔（秒）
   # MCP SSE ping interval (seconds)
   mcp-sse-ping-interval: 30
+  # 是否关闭 MCP 的 localhost DNS 重绑定保护。默认 false。
+  # 仅当可信的本机反向代理或 Cloudflare Tunnel 通过 127.0.0.1 连接、同时保留公网 Host 请求头时才开启。
+  # 开启前请确保 MCP 端口不直接暴露给不可信的本地客户端。
+  # Whether to disable MCP localhost DNS rebinding protection. Defaults to false.
+  # Enable only when a trusted local reverse proxy or Cloudflare Tunnel connects through 127.0.0.1 while preserving the public Host header.
+  # Before enabling, ensure the MCP port is not directly exposed to untrusted local clients.
+  mcp-disable-localhost-protection: false
   # 独立 Web 界面端口。留空则不开启。格式: :port
   # Independent WebGUI port. Leave empty to disable. Format: :port
   webgui-port: ""
@@ -518,4 +525,3 @@ attachment-static:
     # - ".jpeg"
     # - ".gif"
     # - ".pdf"
-

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -51,3 +51,16 @@ user-database:
 	require.True(t, *cfg.Storage.AwsS3.IsEnabled)
 	require.True(t, *cfg.Storage.MinIO.IsEnabled)
 }
+
+func TestLoadConfigMCPDisableLocalhostProtection(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(configPath, []byte(`
+server:
+  mcp-disable-localhost-protection: true
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, _, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.True(t, cfg.Server.MCPDisableLocalhostProtection)
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -27,10 +27,9 @@ type ServerConfig struct {
 	// ExtApiUrl external API URL
 	// ExtApiUrl external API URL
 	// ExtApiUrl 外部访问 API 的地址
-	ExtApiUrl string `yaml:"ext-api-url"`
+	ExtApiUrl          string   `yaml:"ext-api-url"`
 	CORSAllowedOrigins []string `yaml:"cors-allowed-origins"` // CORSAllowedOrigins allowed origins for CORS / CORSAllowedOrigins 跨域允许源白名单
-	TrustedProxies     []string `yaml:"trusted-proxies"`     // TrustedProxies trusted proxies IP/CIDR list / TrustedProxies 可信代理 IP/CIDR 列表
-
+	TrustedProxies     []string `yaml:"trusted-proxies"`      // TrustedProxies trusted proxies IP/CIDR list / TrustedProxies 可信代理 IP/CIDR 列表
 
 	// ShareBaseUrl external share page base URL
 	// ShareBaseUrl 外部分享页面基础 URL
@@ -38,6 +37,9 @@ type ServerConfig struct {
 	// MCPSSEPingInterval MCP SSE ping interval (seconds)
 	// MCPSSEPingInterval MCP SSE 保活心跳间隔（秒）
 	MCPSSEPingInterval int `yaml:"mcp-sse-ping-interval" default:"30"`
+	// MCPDisableLocalhostProtection disables MCP DNS rebinding protection for trusted loopback proxies
+	// MCPDisableLocalhostProtection 为可信的本机反向代理关闭 MCP DNS 重绑定保护
+	MCPDisableLocalhostProtection bool `yaml:"mcp-disable-localhost-protection"`
 	// CustomResponseHeaders custom response headers for all requests
 	// CustomResponseHeaders 所有请求的自定义响应头
 	CustomResponseHeaders map[string]string `yaml:"custom-response-headers"` // Custom response headers mapped to string

--- a/internal/routers/mcp_router/mcp.go
+++ b/internal/routers/mcp_router/mcp.go
@@ -69,11 +69,13 @@ func NewMCPHandler(appContainer *app.App, wss *pkgapp.WebsocketServer) *MCPHandl
 	}
 
 	srv := NewMCPServer(appContainer, wss)
+	sseLocalhostOption, streamableLocalhostOption := mcpLocalhostProtectionOptions(cfg.Server.MCPDisableLocalhostProtection)
 
 	sseOptions := []mcpserver.SSEOption{
 		mcpserver.WithMessageEndpoint("/api/mcp/message"),
 		mcpserver.WithKeepAlive(true),
 		mcpserver.WithKeepAliveInterval(pingInterval),
+		sseLocalhostOption,
 		mcpserver.WithSSEContextFunc(func(ctx context.Context, r *http.Request) context.Context {
 			if val := r.Context().Value("uid"); val != nil {
 				ctx = context.WithValue(ctx, "uid", val)
@@ -89,6 +91,7 @@ func NewMCPHandler(appContainer *app.App, wss *pkgapp.WebsocketServer) *MCPHandl
 	// StreamableHTTP server shares the same MCPServer instance as SSEServer.
 	// StreamableHTTP 服务与 SSEServer 共享同一 MCPServer 实例。
 	streamableOptions := []mcpserver.StreamableHTTPOption{
+		streamableLocalhostOption,
 		mcpserver.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
 			// uid is pre-injected into the request context by HandleStreamableHTTP
 			// before calling ServeHTTP, so we forward it here.
@@ -112,6 +115,10 @@ func NewMCPHandler(appContainer *app.App, wss *pkgapp.WebsocketServer) *MCPHandl
 		extApiUrl:        strings.TrimSuffix(cfg.Server.ExtApiUrl, "/"),
 		cfg:              cfg,
 	}
+}
+
+func mcpLocalhostProtectionOptions(disable bool) (mcpserver.SSEOption, mcpserver.StreamableHTTPOption) {
+	return mcpserver.WithSSEDisableLocalhostProtection(disable), mcpserver.WithDisableLocalhostProtection(disable)
 }
 
 func (h *MCPHandler) HandleSSE(c *gin.Context) {

--- a/internal/routers/mcp_router/mcp_test.go
+++ b/internal/routers/mcp_router/mcp_test.go
@@ -1,11 +1,15 @@
 package mcp_router
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,4 +34,50 @@ func TestHandleSSE_HEAD(t *testing.T) {
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
 	assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
 	assert.Equal(t, "keep-alive", w.Header().Get("Connection"))
+}
+
+func TestMCPLocalhostProtectionOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		disable    bool
+		wantStatus int
+	}{
+		{name: "enabled by default", disable: false, wantStatus: http.StatusForbidden},
+		{name: "disabled for trusted loopback proxy", disable: true, wantStatus: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := server.NewMCPServer("localhost-protection-test", "1.0.0")
+			sseOption, streamableOption := mcpLocalhostProtectionOptions(tt.disable)
+
+			sseServer := server.NewSSEServer(mcpServer, sseOption)
+			sseRecorder := httptest.NewRecorder()
+			sseRequest := httptest.NewRequest(http.MethodPost, "http://vault.example.com/api/mcp/message", strings.NewReader("{}"))
+			sseRequest = sseRequest.WithContext(context.WithValue(
+				sseRequest.Context(),
+				http.LocalAddrContextKey,
+				&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9000},
+			))
+			sseServer.MessageHandler().ServeHTTP(sseRecorder, sseRequest)
+
+			streamableServer := server.NewStreamableHTTPServer(mcpServer, streamableOption)
+			streamableRecorder := httptest.NewRecorder()
+			streamableRequest := httptest.NewRequest(http.MethodPost, "http://vault.example.com/api/mcp", strings.NewReader("{}"))
+			streamableRequest = streamableRequest.WithContext(context.WithValue(
+				streamableRequest.Context(),
+				http.LocalAddrContextKey,
+				&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9000},
+			))
+			streamableServer.ServeHTTP(streamableRecorder, streamableRequest)
+
+			if tt.wantStatus != 0 {
+				assert.Equal(t, tt.wantStatus, sseRecorder.Code)
+				assert.Equal(t, tt.wantStatus, streamableRecorder.Code)
+				return
+			}
+			assert.NotEqual(t, http.StatusForbidden, sseRecorder.Code)
+			assert.NotEqual(t, http.StatusForbidden, streamableRecorder.Code)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- add an opt-in `server.mcp-disable-localhost-protection` setting, defaulting to `false`
- pass the setting to both the SSE and Streamable HTTP MCP transports
- document the security boundary for trusted local reverse proxies and Cloudflare Tunnel
- add config-loading and transport regression tests

## Root cause

mcp-go rejects requests when the server-side local address is loopback but the request preserves a public `Host` header. This is secure by default, but it also rejects trusted same-host reverse proxies such as `cloudflared -> 127.0.0.1:9000`.

The new option keeps DNS rebinding protection enabled by default. Operators must explicitly disable it, and the sample config warns that the MCP port must not be exposed to untrusted local clients.

## Validation

- `git diff --check`
- `go test ./internal/routers/mcp_router ./internal/app`
- `go test ./...` was also run; packages related to this change pass. The upstream tree currently has unrelated failures:
  - `internal/middleware`: existing test fake does not implement `TokenService.CleanExpired`
  - `internal/service`: Git sync test uses a repository URL rejected by the private-network safety check

Closes #424.
